### PR TITLE
fix: coredump after logout

### DIFF
--- a/misc/xdg-desktop-portal-dde.service.in
+++ b/misc/xdg-desktop-portal-dde.service.in
@@ -8,3 +8,4 @@ Type=dbus
 BusName=org.freedesktop.impl.portal.desktop.dde
 ExecStart=@CMAKE_INSTALL_FULL_LIBEXECDIR@/xdg-desktop-portal-dde
 Restart=on-failure
+RestartPreventExitStatus=1


### PR DESCRIPTION
After logout, the systemd starts xdg-desktop-portal-dde all the time

Log: coredump after logout