### PR TITLE
fix: wayland上 chromeium112版本上传文件无法多选

### DIFF
--- a/src/filechooser.cpp
+++ b/src/filechooser.cpp
@@ -196,6 +196,11 @@ uint FileChooserPortal::OpenFile(const QDBusObjectPath &handle,
         OptionList optionList = qdbus_cast<OptionList>(options.value(QStringLiteral("choices")));
         //        optionsWidget.reset(CreateChoiceControls(optionList, checkboxes, comboboxes));
     }
+
+    if (options.contains(QStringLiteral("multiple"))) {
+        multiple = options.value("multiple").toBool();
+    }
+
     QFileDialog fileDialog;
     Utils::setParentWindow(&fileDialog, parent_window);
     auto request = new Request(handle, QVariant(), &fileDialog);


### PR DESCRIPTION
xdg-desktop-portal-dde 的 filechooser未给multiple字段赋值

Log: wayland上 chromeium112版本上传文件无法多选
Bug: https://pms.uniontech.com/bug-view-267187.html
Influence: 调出文馆对话框文件多选文件