### PR TITLE
fix: 修复调用选择文件对话框时无法选择文件夹

### DIFF
--- a/src/filechooser.cpp
+++ b/src/filechooser.cpp
@@ -159,6 +159,10 @@ uint FileChooserPortal::OpenFile(const QDBusObjectPath &handle,
     parseFilters(options, nameFilters, mimeTypeFilters, allFilters, selectedMimeTypeFilter);
 
     // open directory
+    if (options.contains(QStringLiteral("directory"))) {
+        directory = options.value("directory").toBool();
+    }
+
     if (directory && !options.contains(QStringLiteral("choices"))) {
         QFileDialog dirDialog;
         dirDialog.setWindowTitle(title);


### PR DESCRIPTION
directory字段未更新, 判断成选择文件

Log:
Task: https://pms.uniontech.com/task-view-360597.html Influence: 拉起的选择文件对话框