### PR TITLE
fix: add Settings portal interface to dde.portal

### DIFF
--- a/misc/dde.portal
+++ b/misc/dde.portal
@@ -1,4 +1,4 @@
 [portal]
 DBusName=org.freedesktop.impl.portal.desktop.dde
-Interfaces=org.freedesktop.impl.portal.Screenshot;org.freedesktop.impl.portal.Notification;org.freedesktop.impl.portal.FileChooser;org.freedesktop.impl.portal.Wallpaper;org.freedesktop.impl.portal.ScreenCast;org.freedesktop.impl.portal.RemoteDesktop;org.freedesktop.impl.portal.Access
+Interfaces=org.freedesktop.impl.portal.Screenshot;org.freedesktop.impl.portal.Notification;org.freedesktop.impl.portal.FileChooser;org.freedesktop.impl.portal.Wallpaper;org.freedesktop.impl.portal.ScreenCast;org.freedesktop.impl.portal.RemoteDesktop;org.freedesktop.impl.portal.Access;org.freedesktop.impl.portal.Settings
 UseIn=DDE


### PR DESCRIPTION
Added org.freedesktop.impl.portal.Settings to the Interfaces list in dde.portal configuration file. This change enables support for the Settings portal interface in the DDE environment, allowing applications to access system settings through the portal API. The modification ensures compatibility with applications that rely on this interface for system settings management.

fix: 在 dde.portal 中添加 Settings 门户接口

在 dde.portal 配置文件的 Interfaces 列表中添加了
org.freedesktop.impl.portal.Settings。此更改启用了 DDE 环境对 Settings 门户接口的支持，允许应用程序通过门户 API 访问系统设置。该修改确保了与依
赖此接口进行系统设置管理的应用程序的兼容性。

pms: TASK-368711