### PR TITLE
fix: improve palette change handling and translation loading

### DIFF
--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -13,6 +13,7 @@
 #include <QDBusMetaType>
 #include <QLoggingCategory>
 #include <QPalette>
+#include <QEvent>
 
 #define NO_PREFERENCE 0
 #define PREFER_DARK_APPEARANCE 1
@@ -71,7 +72,15 @@ SettingsPortal::SettingsPortal(QObject *parent)
     : QDBusAbstractAdaptor(parent)
 {
     qDBusRegisterMetaType<VariantMapMap>();
-    connect(qApp, &QApplication::paletteChanged, this, &SettingsPortal::onPaletteChanged);
+    qApp->installEventFilter(this);
+}
+
+bool SettingsPortal::eventFilter(QObject *obj, QEvent *event)
+{
+    if (event->type() == QEvent::ApplicationPaletteChange) {
+        onPaletteChanged(qApp->palette());
+    }
+    return QDBusAbstractAdaptor::eventFilter(obj, event);
 }
 
 void SettingsPortal::Read(const QString &group, const QString &key)

--- a/src/settings.h
+++ b/src/settings.h
@@ -8,6 +8,7 @@
 #include <QDBusObjectPath>
 #include <qdbusextratypes.h>
 #include <qobjectdefs.h>
+#include <QEvent>
 
 class SettingsPortal : public QDBusAbstractAdaptor
 {
@@ -19,6 +20,7 @@ class SettingsPortal : public QDBusAbstractAdaptor
 public:
     explicit SettingsPortal(QObject *parent);
     ~SettingsPortal() = default;
+    bool eventFilter(QObject *obj, QEvent *event) override;
 
 public slots:
     void ReadAll(const QStringList &groups);

--- a/src/xdg-desktop-portal-dde.cpp
+++ b/src/xdg-desktop-portal-dde.cpp
@@ -39,7 +39,9 @@ int main(int argc, char *argv[])
     QString languagePath = QStandardPaths::locate(QStandardPaths::GenericDataLocation,
                                                   QString("xdg-desktop-portal-dde/translations"),
                                                   QStandardPaths::LocateDirectory);
-    translator.load(languagePath+"/xdg-desktop-portal-dde_" + QLocale::system().name());
+    if (!translator.load(languagePath+"/xdg-desktop-portal-dde_" + QLocale::system().name())) {
+        qCWarning(XdgDesktopDDE) << "Failed to load translation file for locale:" << QLocale::system().name();
+    }
     a.installTranslator(&translator);
 
     QDBusConnection sessionBus = QDBusConnection::sessionBus();


### PR DESCRIPTION
1. Changed palette change detection from signal to event filter for more reliable handling
2. Added QEvent include in both .h and .cpp files for the new event filter implementation
3. Added error logging when translation loading fails to help diagnose localization issues
4. The event filter approach ensures palette changes are caught even when signals might be missed

The modifications provide more robust theme change detection and better error reporting for translation issues, which helps with debugging and improves reliability of the portal service.

fix: 改进调色板变更处理和翻译加载

1. 将调色板变更检测从信号改为事件过滤器，以获得更可靠的处理
2. 在.h和.cpp文件中添加QEvent包含以支持新的事件过滤器实现
3. 添加翻译加载失败时的错误日志记录，帮助诊断本地化问题
4. 事件过滤器方法确保即使信号可能丢失时也能捕获调色板变化

这些修改提供了更强大的主题变更检测和更好的翻译问题错误报告，有助于调试并
提高门户服务的可靠性。

pms: TASK-368711