### PR TITLE
feat: [filedialog] Not show name filter detail info.

### DIFF
--- a/src/filechooser.cpp
+++ b/src/filechooser.cpp
@@ -168,7 +168,7 @@ uint FileChooserPortal::OpenFile(const QDBusObjectPath &handle,
         dirDialog.setWindowTitle(title);
         dirDialog.setModal(modal);
         dirDialog.setFileMode(QFileDialog::Directory);
-        dirDialog.setOptions(QFileDialog::ShowDirsOnly);
+        dirDialog.setOptions(QFileDialog::ShowDirsOnly | QFileDialog::HideNameFilterDetails);
         dirDialog.setSupportedSchemes(QStringList{QStringLiteral("file")});
         if (!acceptText.isEmpty()) {
             dirDialog.setLabelText(QFileDialog::Accept, acceptText);
@@ -212,6 +212,7 @@ uint FileChooserPortal::OpenFile(const QDBusObjectPath &handle,
     fileDialog.setWindowTitle(title);
     fileDialog.setModal(modal);
     fileDialog.setFileMode(multiple ? QFileDialog::FileMode::ExistingFiles : QFileDialog::FileMode::ExistingFile);
+    fileDialog.setOptions(QFileDialog::HideNameFilterDetails);
     if (!acceptText.isEmpty()) {
         fileDialog.setLabelText(QFileDialog::Accept, acceptText);
     }
@@ -302,6 +303,7 @@ uint FileChooserPortal::SaveFile(const QDBusObjectPath &handle,
     fileDialog.setModal(modal);
     fileDialog.setAcceptMode(QFileDialog::AcceptSave);
     fileDialog.setOption(QFileDialog::DontConfirmOverwrite, false);
+    fileDialog.setOption(QFileDialog::HideNameFilterDetails, true);
     fileDialog.setDirectory(QString::fromLocal8Bit(current_folder));
     if (!current_name.isEmpty())
         fileDialog.selectFile(current_name);
@@ -377,6 +379,7 @@ uint FileChooserPortal::SaveFiles(const QDBusObjectPath &handle, const QString &
     fileDialog.setModal(modal);
     fileDialog.setAcceptMode(QFileDialog::AcceptSave);
     fileDialog.setOption(QFileDialog::DontConfirmOverwrite, false);
+    fileDialog.setOption(QFileDialog::HideNameFilterDetails, true);
     fileDialog.setDirectory(QString::fromLocal8Bit(current_folder));
     fileDialog.setFileMode(QFileDialog::FileMode::ExistingFiles);
     if (!acceptText.isEmpty()) {


### PR DESCRIPTION
-- When open by xdg chooser, not show name filter detail info.

Log: add feature of file dialog
Task: https://pms.uniontech.com/task-view-378479.html