### PR TITLE
feat: add current folder support to file chooser

### DIFF
--- a/src/filechooser.cpp
+++ b/src/filechooser.cpp
@@ -147,6 +147,11 @@ uint FileChooserPortal::OpenFile(const QDBusObjectPath &handle,
     DECLEAR_PARA_WITH_FALLBACK(multiple, toBool, false);
     // Whether to select for folders instead of files. Default is to select files.
     DECLEAR_PARA_WITH_FALLBACK(directory, toBool, false);
+    // Suggested folder to save the files in. The byte array is expected to be null-terminated.
+    DECLEAR_PARA(current_folder, toByteArray);
+    while (current_folder.endsWith('\0')) {
+        current_folder.chop(1);
+    }
     // The label for the accept button. Mnemonic underlines are allowed.
     const QString &acceptText = parseAcceptLabel(options);
 
@@ -170,6 +175,7 @@ uint FileChooserPortal::OpenFile(const QDBusObjectPath &handle,
         dirDialog.setFileMode(QFileDialog::Directory);
         dirDialog.setOptions(QFileDialog::ShowDirsOnly | QFileDialog::HideNameFilterDetails);
         dirDialog.setSupportedSchemes(QStringList{QStringLiteral("file")});
+        dirDialog.setDirectory(QString::fromLocal8Bit(current_folder));
         if (!acceptText.isEmpty()) {
             dirDialog.setLabelText(QFileDialog::Accept, acceptText);
         }
@@ -213,6 +219,7 @@ uint FileChooserPortal::OpenFile(const QDBusObjectPath &handle,
     fileDialog.setModal(modal);
     fileDialog.setFileMode(multiple ? QFileDialog::FileMode::ExistingFiles : QFileDialog::FileMode::ExistingFile);
     fileDialog.setOptions(QFileDialog::HideNameFilterDetails);
+    fileDialog.setDirectory(QString::fromLocal8Bit(current_folder));
     if (!acceptText.isEmpty()) {
         fileDialog.setLabelText(QFileDialog::Accept, acceptText);
     }


### PR DESCRIPTION
1. Added support for current_folder parameter in OpenFile method
2. Parse current_folder from D-Bus options and remove null terminators
3. Set initial directory for both file and folder selection dialogs
4. Maintain backward compatibility with existing functionality

Log: File chooser now respects suggested folder location from applications

Influence:
1. Test file selection dialog opens in specified folder when current_folder is provided
2. Verify folder selection dialog respects current_folder parameter
3. Test with various folder paths including special characters
4. Verify null terminator removal works correctly
5. Test backward compatibility when current_folder is not provided
6. Verify both single and multiple file selection modes work with current_folder

feat: 为文件选择器添加当前文件夹支持

1. 在 OpenFile 方法中添加对 current_folder 参数的支持
2. 从 D-Bus 选项解析 current_folder 并移除空终止符
3. 为文件和文件夹选择对话框设置初始目录
4. 保持与现有功能的向后兼容性

Log: 文件选择器现在会尊重应用程序建议的文件夹位置

Influence:
1. 测试当提供 current_folder 时，文件选择对话框是否在指定文件夹中打开
2. 验证文件夹选择对话框是否遵循 current_folder 参数
3. 使用包含特殊字符的各种文件夹路径进行测试
4. 验证空终止符移除功能正常工作
5. 测试未提供 current_folder 时的向后兼容性
6. 验证单文件和批量文件选择模式都能与 current_folder 正常工作