### PR TITLE
feat: add qt6-tools-dev to build dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -24,6 +24,7 @@ Build-Depends:
   wayland-protocols,
   qt6-declarative-dev,
   libdtk6declarative-dev,
+  qt6-tools-dev,
 Standards-Version: 4.5.0
 
 Package: xdg-desktop-portal-dde


### PR DESCRIPTION
Added qt6-tools-dev to the Build-Depends list in debian/control. This package is required for building the project as it provides development tools and libraries for Qt6, ensuring all necessary Qt6 components are available during the compilation process.

Influence:
1. Verify the package builds successfully with the new dependency
2. Test that all Qt6 development tools are properly accessible during build
3. Ensure no missing dependencies errors occur during package compilation
4. Confirm the final built package functions correctly

feat: 在构建依赖中添加 qt6-tools-dev

在 debian/control 文件的 Build-Depends 列表中添加了 qt6-tools-dev 包。该 包是构建项目所必需的，它提供了 Qt6 的开发工具和库，确保在编译过程中所有
必要的 Qt6 组件都可用。

Influence:
1. 验证添加新依赖后软件包是否成功构建
2. 测试构建过程中所有 Qt6 开发工具是否正确可访问
3. 确保软件包编译过程中不会出现缺少依赖的错误
4. 确认最终构建的软件包功能正常