### PR TITLE
chore(deps): bump treeland-protocols dependency to >= 0.5.9

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -18,7 +18,7 @@ Build-Depends:
   wlr-protocols,
   libdtk6widget-dev,
   libdtk6core-dev,
-  treeland-protocols,
+  treeland-protocols (>= 0.5.9),
   libgbm-dev,
   libdrm-dev,
   wayland-protocols,


### PR DESCRIPTION
Update the build dependency to match the latest treeland-protocols release with breaking changes.

Log: bump treeland-protocolsdependencyversionto0.5.9 PMS:BUG-364795
Influence:BreakingAPIchangesintreeland-protocols0.5.9,bumprequiredversion

## Summary by Sourcery

Build:
- Bump treeland-protocols build dependency in Debian control file to version 0.5.9 or later.