### PR TITLE
[AI-Generated] fix: wayland: fix fullscreen screenshots with fractional scaling

### DIFF
--- a/src/wayland/protocols/screencopy.cpp
+++ b/src/wayland/protocols/screencopy.cpp
@@ -9,6 +9,13 @@ ScreenCopyFrame::ScreenCopyFrame(struct ::zwlr_screencopy_frame_v1 *object)
     , QtWayland::zwlr_screencopy_frame_v1(object)
 { }
 
+ScreenCopyFrame::~ScreenCopyFrame()
+{
+    QObject::disconnect(this, nullptr, nullptr, nullptr);
+    if (isInitialized())
+        destroy();
+}
+
 void ScreenCopyFrame::zwlr_screencopy_frame_v1_buffer(uint32_t format,
                                                       uint32_t width,
                                                       uint32_t height,

--- a/src/wayland/protocols/screencopy.h
+++ b/src/wayland/protocols/screencopy.h
@@ -20,6 +20,7 @@ class ScreenCopyFrame : public QObject, public QtWayland::zwlr_screencopy_frame_
     Q_OBJECT
 public:
     ScreenCopyFrame(struct ::zwlr_screencopy_frame_v1 *object);
+    ~ScreenCopyFrame() override;
 
 Q_SIGNALS:
     void buffer(uint32_t format, uint32_t width, uint32_t height, uint32_t stride);

--- a/src/wayland/request2.cpp
+++ b/src/wayland/request2.cpp
@@ -19,18 +19,23 @@ Request2::Request2(const QDBusObjectPath &handle, QObject *parent, const QString
     : QDBusVirtualObject(parent)
     , m_data(data)
     , m_portalName(portalName)
+    , m_path(handle.path())
 {
     auto sessionBus = QDBusConnection::sessionBus();
-    if (sessionBus.registerVirtualObject(handle.path(), this, QDBusConnection::VirtualObjectRegisterOption::SubPath)) {
-        connect(this, &Request2::closeRequested, this, [this, handle]() {
-            QDBusConnection::sessionBus().unregisterObject(handle.path());
+    if (sessionBus.registerVirtualObject(m_path, this, QDBusConnection::VirtualObjectRegisterOption::SubPath)) {
+        connect(this, &Request2::closeRequested, this, [this]() {
             deleteLater();
         });
     } else {
         qCDebug(PORTAL_COMMON) << sessionBus.lastError().message();
-        qCDebug(PORTAL_COMMON) << "Failed to register request object for" << handle.path();
+        qCDebug(PORTAL_COMMON) << "Failed to register request object for" << m_path;
         deleteLater();
     }
+}
+
+Request2::~Request2()
+{
+    QDBusConnection::sessionBus().unregisterObject(m_path);
 }
 
 bool Request2::handleMessage(const QDBusMessage &message, const QDBusConnection &connection)

--- a/src/wayland/request2.h
+++ b/src/wayland/request2.h
@@ -21,6 +21,7 @@ class Request2 : public QDBusVirtualObject
     Q_OBJECT
 public:
     explicit Request2(const QDBusObjectPath &handle, QObject *parent = nullptr, const QString &portalName = QString(), const QVariant &data = QVariant());
+    ~Request2() override;
 
     bool handleMessage(const QDBusMessage &message, const QDBusConnection &connection) override;
     QString introspect(const QString &path) const override;
@@ -47,4 +48,5 @@ Q_SIGNALS:
 private:
     const QVariant m_data;
     const QString m_portalName;
+    const QString m_path;
 };

--- a/src/wayland/screenshotportal.cpp
+++ b/src/wayland/screenshotportal.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -12,7 +12,6 @@
 #include <QScreen>
 #include <QPainter>
 #include <QDir>
-#include <QRegion>
 #include <QStandardPaths>
 
 #include <private/qwaylandscreen_p.h>
@@ -36,6 +35,112 @@ static void destroyScreenCaptureInfo(std::list<std::shared_ptr<ScreenCaptureInfo
             delete info->capturedFrame;
         }
     }
+}
+
+static bool captureInfoHasImage(const std::shared_ptr<ScreenCaptureInfo> &info)
+{
+    return info && info->screen && info->shmBuffer && info->shmBuffer->image() &&
+           !info->shmBuffer->image()->isNull();
+}
+
+static int captureInfoAxisStart(const std::shared_ptr<ScreenCaptureInfo> &info, bool horizontal)
+{
+    const QRect geometry = info->screen->geometry();
+    return horizontal ? geometry.x() : geometry.y();
+}
+
+static int captureInfoAxisEnd(const std::shared_ptr<ScreenCaptureInfo> &info, bool horizontal)
+{
+    const QRect geometry = info->screen->geometry();
+    return horizontal ? geometry.x() + geometry.width() :
+                        geometry.y() + geometry.height();
+}
+
+static qreal captureInfoAxisScale(const std::shared_ptr<ScreenCaptureInfo> &info, bool horizontal)
+{
+    const QRect geometry = info->screen->geometry();
+    const QImage *image = info->shmBuffer->image();
+    const int logicalSize = horizontal ? geometry.width() : geometry.height();
+    const int pixelSize = horizontal ? image->width() : image->height();
+
+    if (logicalSize <= 0 || pixelSize <= 0)
+        return 1.0;
+
+    return static_cast<qreal>(pixelSize) / logicalSize;
+}
+
+static int logicalAxisToPhysical(const std::list<std::shared_ptr<ScreenCaptureInfo>> &captureList,
+                                 int logical,
+                                 bool horizontal)
+{
+    bool haveOrigin = false;
+    int origin = 0;
+    int pos;
+    int physical = 0;
+
+    for (const auto &info : std::as_const(captureList)) {
+        if (!captureInfoHasImage(info))
+            continue;
+
+        const int start = captureInfoAxisStart(info, horizontal);
+        if (!haveOrigin || start < origin) {
+            origin = start;
+            haveOrigin = true;
+        }
+    }
+    if (!haveOrigin || logical <= origin)
+        return 0;
+
+    pos = origin;
+    while (pos < logical) {
+        int next = logical;
+        qreal scale = 1.0;
+        bool covered = false;
+
+        for (const auto &info : std::as_const(captureList)) {
+            if (!captureInfoHasImage(info))
+                continue;
+
+            const int start = captureInfoAxisStart(info, horizontal);
+            const int end = captureInfoAxisEnd(info, horizontal);
+
+            if (start <= pos && end > pos) {
+                const qreal outputScale = captureInfoAxisScale(info, horizontal);
+                next = qMin(next, end);
+                scale = covered ? qMax(scale, outputScale) : outputScale;
+                covered = true;
+            } else if (start > pos) {
+                next = qMin(next, start);
+            }
+        }
+
+        if (next <= pos)
+            break;
+
+        if (!covered) {
+            qCWarning(portalWayland) << "Gap in output layout at logical position" << pos
+                                     << "to" << next
+                                     << "on" << (horizontal ? "X" : "Y")
+                                     << "axis, defaulting to scale 1.0";
+        }
+
+        physical += qRound((next - pos) * scale);
+        pos = next;
+    }
+
+    return physical;
+}
+
+static QRect captureInfoPhysicalRect(const std::list<std::shared_ptr<ScreenCaptureInfo>> &captureList,
+                                     const std::shared_ptr<ScreenCaptureInfo> &info)
+{
+    const QRect geometry = info->screen->geometry();
+    const QImage *image = info->shmBuffer->image();
+
+    return QRect(logicalAxisToPhysical(captureList, geometry.x(), true),
+                 logicalAxisToPhysical(captureList, geometry.y(), false),
+                 image->width(),
+                 image->height());
 }
 
 ScreenshotPortalWayland::ScreenshotPortalWayland(PortalWaylandContext *context)
@@ -66,12 +171,10 @@ QString ScreenshotPortalWayland::fullScreenShot()
     int pendingCapture = 0;
     auto screenCopyManager = context()->screenCopyManager();
     QEventLoop eventLoop;
-    QRegion outputRegion;
     QImage::Format formatLast;
     // Capture each output
     for (auto screen : waylandDisplay()->screens()) {
         auto info = std::make_shared<ScreenCaptureInfo>();
-        outputRegion += screen->geometry();
         auto output = screen->output();
         info->capturedFrame = screenCopyManager->captureOutput(false, output);
         info->screen = screen;
@@ -118,19 +221,35 @@ QString ScreenshotPortalWayland::fullScreenShot()
         });
     }
     eventLoop.exec();
-    // Cat them according to layout
-    QImage image(outputRegion.boundingRect().size(), formatLast);
+
+    QRect physicalOutputRegion;
+    for (const auto &info : std::as_const(captureList)) {
+        if (!captureInfoHasImage(info))
+            continue;
+
+        physicalOutputRegion = physicalOutputRegion.united(captureInfoPhysicalRect(captureList, info));
+    }
+    if (physicalOutputRegion.isEmpty()) {
+        qCWarning(portalWayland) << "No valid output images are available for screenshot";
+        destroyScreenCaptureInfo(captureList);
+        return "";
+    }
+
+    // Cat outputs according to their physical pixel buffers. QScreen geometry
+    // is logical under fractional scaling, while screencopy images are pixels.
+    QImage image(physicalOutputRegion.size(), formatLast);
+    image.fill(Qt::transparent);
     QPainter p(&image);
     p.setRenderHint(QPainter::Antialiasing);
     for (const auto &info : std::as_const(captureList)) {
-        if (info->shmBuffer) {
-            QRect targetRect = info->screen->geometry();
-            // Convert to screen image local coordinates
-            auto sourceRect = targetRect;
-            sourceRect.moveTo(sourceRect.topLeft() - info->screen->geometry().topLeft());
-            p.drawImage(targetRect, *info->shmBuffer->image(), sourceRect);
+        if (captureInfoHasImage(info)) {
+            const QImage *outputImage = info->shmBuffer->image();
+            QRect targetRect = captureInfoPhysicalRect(captureList, info);
+            targetRect.translate(-physicalOutputRegion.topLeft());
+            p.drawImage(targetRect, *outputImage, QRect(QPoint(0, 0), outputImage->size()));
         } else {
-            qCWarning(portalWayland) << "image is null!!!";
+            qCWarning(portalWayland) << "No image available for output geometry"
+                                     << (info && info->screen ? info->screen->geometry() : QRect());
         }
     }
     static const char *SaveFormat = "PNG";

--- a/src/wayland/screenshotportal.cpp
+++ b/src/wayland/screenshotportal.cpp
@@ -7,16 +7,19 @@
 #include "protocols/treelandcapture.h"
 #include "loggings.h"
 #include "dbushelpers.h"
+#include "request2.h"
 
 #include <QApplication>
+#include <QDateTime>
 #include <QScreen>
 #include <QPainter>
 #include <QDir>
 #include <QStandardPaths>
+#include <QEventLoop>
+#include <QPointer>
 
 #include <private/qwaylandscreen_p.h>
 
-Q_LOGGING_CATEGORY(portalWayland, "dde.portal.wayland");
 struct ScreenCaptureInfo {
     QtWaylandClient::QWaylandScreen *screen {nullptr};
     QPointer<ScreenCopyFrame> capturedFrame {nullptr};
@@ -24,7 +27,7 @@ struct ScreenCaptureInfo {
     QtWayland::zwlr_screencopy_frame_v1::flags flags;
 };
 
-static void destroyScreenCaptureInfo(std::list<std::shared_ptr<ScreenCaptureInfo>> captureList)
+static void destroyScreenCaptureInfo(const std::list<std::shared_ptr<ScreenCaptureInfo>> &captureList)
 {
     for (const auto &info : std::as_const(captureList)) {
         if (info->shmBuffer) {
@@ -118,10 +121,10 @@ static int logicalAxisToPhysical(const std::list<std::shared_ptr<ScreenCaptureIn
             break;
 
         if (!covered) {
-            qCWarning(portalWayland) << "Gap in output layout at logical position" << pos
-                                     << "to" << next
-                                     << "on" << (horizontal ? "X" : "Y")
-                                     << "axis, defaulting to scale 1.0";
+            qCWarning(SCREESHOT) << "Gap in output layout at logical position" << pos
+                                  << "to" << next
+                                  << "on" << (horizontal ? "X" : "Y")
+                                  << "axis, defaulting to scale 1.0";
         }
 
         physical += qRound((next - pos) * scale);
@@ -172,6 +175,15 @@ QString ScreenshotPortalWayland::fullScreenShot()
     auto screenCopyManager = context()->screenCopyManager();
     QEventLoop eventLoop;
     QImage::Format formatLast;
+
+    if (m_currentScreenshotRequest) {
+        connect(m_currentScreenshotRequest, &Request2::closeRequested, &eventLoop, [this, &eventLoop, &formatLast] {
+            m_currentScreenshotCancelled = true;
+            formatLast = QImage::Format_ARGB32_Premultiplied;
+            eventLoop.quit();
+        });
+    }
+
     // Capture each output
     for (auto screen : waylandDisplay()->screens()) {
         auto info = std::make_shared<ScreenCaptureInfo>();
@@ -221,6 +233,10 @@ QString ScreenshotPortalWayland::fullScreenShot()
         });
     }
     eventLoop.exec();
+    if (m_currentScreenshotCancelled) {
+        destroyScreenCaptureInfo(captureList);
+        return "";
+    }
 
     QRect physicalOutputRegion;
     for (const auto &info : std::as_const(captureList)) {
@@ -230,7 +246,7 @@ QString ScreenshotPortalWayland::fullScreenShot()
         physicalOutputRegion = physicalOutputRegion.united(captureInfoPhysicalRect(captureList, info));
     }
     if (physicalOutputRegion.isEmpty()) {
-        qCWarning(portalWayland) << "No valid output images are available for screenshot";
+        qCWarning(SCREESHOT) << "No valid output images are available for screenshot";
         destroyScreenCaptureInfo(captureList);
         return "";
     }
@@ -248,8 +264,8 @@ QString ScreenshotPortalWayland::fullScreenShot()
             targetRect.translate(-physicalOutputRegion.topLeft());
             p.drawImage(targetRect, *outputImage, QRect(QPoint(0, 0), outputImage->size()));
         } else {
-            qCWarning(portalWayland) << "No image available for output geometry"
-                                     << (info && info->screen ? info->screen->geometry() : QRect());
+            qCWarning(SCREESHOT) << "No image available for output geometry"
+                                  << (info && info->screen ? info->screen->geometry() : QRect());
         }
     }
     static const char *SaveFormat = "PNG";
@@ -270,6 +286,7 @@ QString ScreenshotPortalWayland::captureInteractively()
 {
     auto captureManager = context()->treelandCaptureManager();
     auto captureContext = captureManager->getContext();
+    bool sourceFailed = false;
     if (!captureContext) {
         return "";
     }
@@ -281,7 +298,21 @@ QString ScreenshotPortalWayland::captureInteractively()
                                  ,nullptr);
     QEventLoop loop;
     connect(captureContext, &TreeLandCaptureContext::sourceReady, &loop, &QEventLoop::quit);
+    connect(captureContext, &TreeLandCaptureContext::sourceFailed, &loop, [&] {
+        sourceFailed = true;
+        loop.quit();
+    });
+    if (m_currentScreenshotRequest) {
+        connect(m_currentScreenshotRequest, &Request2::closeRequested, &loop, [this, &loop] {
+            m_currentScreenshotCancelled = true;
+            loop.quit();
+        });
+    }
     loop.exec();
+    if (m_currentScreenshotCancelled || sourceFailed) {
+        captureManager->releaseCaptureContext(captureContext);
+        return "";
+    }
     auto frame = captureContext->frame();
     QImage result;
     connect(frame, &TreeLandCaptureFrame::ready, this, [this, &result, &loop](QImage image) {
@@ -289,8 +320,15 @@ QString ScreenshotPortalWayland::captureInteractively()
         loop.quit();
     });
     connect(frame, &TreeLandCaptureFrame::failed, &loop, &QEventLoop::quit);
+    if (m_currentScreenshotRequest) {
+        connect(m_currentScreenshotRequest, &Request2::closeRequested, &loop, [this, &loop] {
+            m_currentScreenshotCancelled = true;
+            loop.quit();
+        });
+    }
     loop.exec();
-    if (result.isNull()) return "";
+    captureManager->releaseCaptureContext(captureContext);
+    if (m_currentScreenshotCancelled || result.isNull()) return "";
     auto saveBasePath = QStandardPaths::writableLocation(QStandardPaths::PicturesLocation);
     QDir saveBaseDir(saveBasePath);
     if (!saveBaseDir.exists()) return "";
@@ -308,6 +346,18 @@ uint ScreenshotPortalWayland::Screenshot(const QDBusObjectPath &handle,
                                   const QVariantMap &options,
                                   QVariantMap &results)
 {
+    uint response = PortalResponse::Success;
+    QPointer<Request2> request;
+
+    if (m_screenshotInProgress) {
+        qCWarning(SCREESHOT) << "Rejecting concurrent screenshot request";
+        return PortalResponse::OtherError;
+    }
+    m_screenshotInProgress = true;
+    m_currentScreenshotCancelled = false;
+
+    request = new Request2(handle, this, QStringLiteral("Screenshot"));
+    m_currentScreenshotRequest = request;
     if (options["modal"].toBool()) {
         // TODO if modal, we should block parent_window
     }
@@ -318,8 +368,15 @@ uint ScreenshotPortalWayland::Screenshot(const QDBusObjectPath &handle,
         filePath = fullScreenShot();
     }
     if (filePath.isEmpty()) {
-        return 1;
+        response = m_currentScreenshotCancelled ? PortalResponse::Cancelled :
+                               PortalResponse::OtherError;
+    } else {
+        results.insert(QStringLiteral("uri"), QUrl::fromLocalFile(filePath).toString(QUrl::FullyEncoded));
     }
-    results.insert(QStringLiteral("uri"), QUrl::fromLocalFile(filePath).toString(QUrl::FullyEncoded));
-    return 0;
+    if (request)
+        delete request.data();
+    m_currentScreenshotRequest.clear();
+    m_currentScreenshotCancelled = false;
+    m_screenshotInProgress = false;
+    return response;
 }

--- a/src/wayland/screenshotportal.h
+++ b/src/wayland/screenshotportal.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -8,6 +8,9 @@
 
 #include <QDBusObjectPath>
 #include <QObject>
+#include <QPointer>
+
+class Request2;
 
 class ScreenshotPortalWayland : public AbstractWaylandPortal
 {
@@ -31,4 +34,9 @@ public Q_SLOTS:
                     const QString &parent_window,
                     const QVariantMap &options,
                     QVariantMap &results);
+
+private:
+    QPointer<Request2> m_currentScreenshotRequest;
+    bool m_currentScreenshotCancelled = false;
+    bool m_screenshotInProgress = false;
 };


### PR DESCRIPTION
xdg-desktop-portal-dde在treeland渲染器下且开着分数缩放时, 会导致部分走 xdg-desktop-portal 截图的应用 (比如微信) 截图内容不全, 该PR用于修复这个问题

The Wayland screenshot backend used QScreen::geometry() to size and compose fullscreen screenshots. On fractional scaling setups, QScreen geometry is expressed in logical coordinates, while screencopy returns pixel buffers. This caused screenshots to be saved at the logical size, for example 2048x1152 on a 2560x1440 output at 125% scale.

Compose the final screenshot in physical pixel coordinates instead. Use each screencopy buffer's actual image size as the output size, map the logical output position to physical coordinates, and draw the captured image with a device pixel ratio of 1.0.

This makes the Screenshot portal return full-resolution images and avoids blank right/bottom regions for portal clients on fractional scaling setups.