### PR TITLE
fix: make Wayland Screenshot requests closable and robust

### DIFF
--- a/src/wayland/protocols/screencopy.cpp
+++ b/src/wayland/protocols/screencopy.cpp
@@ -9,6 +9,13 @@ ScreenCopyFrame::ScreenCopyFrame(struct ::zwlr_screencopy_frame_v1 *object)
     , QtWayland::zwlr_screencopy_frame_v1(object)
 { }
 
+ScreenCopyFrame::~ScreenCopyFrame()
+{
+    QObject::disconnect(this, nullptr, nullptr, nullptr);
+    if (isInitialized())
+        destroy();
+}
+
 void ScreenCopyFrame::zwlr_screencopy_frame_v1_buffer(uint32_t format,
                                                       uint32_t width,
                                                       uint32_t height,

--- a/src/wayland/protocols/screencopy.h
+++ b/src/wayland/protocols/screencopy.h
@@ -20,6 +20,7 @@ class ScreenCopyFrame : public QObject, public QtWayland::zwlr_screencopy_frame_
     Q_OBJECT
 public:
     ScreenCopyFrame(struct ::zwlr_screencopy_frame_v1 *object);
+    ~ScreenCopyFrame() override;
 
 Q_SIGNALS:
     void buffer(uint32_t format, uint32_t width, uint32_t height, uint32_t stride);

--- a/src/wayland/protocols/treelandcapture.cpp
+++ b/src/wayland/protocols/treelandcapture.cpp
@@ -60,10 +60,11 @@ void TreeLandCaptureContext::releaseCaptureFrame() {
 void TreeLandCaptureFrame::treeland_capture_frame_v1_buffer(uint32_t format, uint32_t width, uint32_t height, uint32_t stride)
 {
     if (stride != width * 4) {
-        qCDebug(PORTAL_COMMON)
+        qCWarning(PORTAL_COMMON)
                 << "Receive a buffer format which is not compatible with QWaylandShmBuffer."
                 << "format:" << format << "width:" << width << "height:" << height
                 << "stride:" << stride;
+        Q_EMIT failed();
         return;
     }
     if (m_pendingShmBuffer)
@@ -79,6 +80,13 @@ void TreeLandCaptureFrame::treeland_capture_frame_v1_flags(uint32_t flags)
 
 void TreeLandCaptureFrame::treeland_capture_frame_v1_ready()
 {
+    if (!m_pendingShmBuffer || !m_pendingShmBuffer->image() || m_pendingShmBuffer->image()->isNull()) {
+        qCWarning(PORTAL_COMMON) << "Treeland capture frame is ready without a valid image";
+        delete m_pendingShmBuffer;
+        m_pendingShmBuffer = nullptr;
+        Q_EMIT failed();
+        return;
+    }
     if (m_shmBuffer)
         delete m_shmBuffer;
     m_shmBuffer = m_pendingShmBuffer;

--- a/src/wayland/protocols/treelandcapture.h
+++ b/src/wayland/protocols/treelandcapture.h
@@ -25,7 +25,8 @@ public:
     {
         delete m_shmBuffer;
         delete m_pendingShmBuffer;
-        destroy();
+        if (isInitialized())
+            destroy();
     }
 
     inline uint flags() const { return m_flags; }
@@ -54,7 +55,8 @@ public:
     ~TreeLandCaptureContext() override
     {
         releaseCaptureFrame();
-        destroy();
+        if (isInitialized())
+            destroy();
     }
 
     inline QRect captureRegion() const { return m_captureRegion; }

--- a/src/wayland/request2.cpp
+++ b/src/wayland/request2.cpp
@@ -19,18 +19,23 @@ Request2::Request2(const QDBusObjectPath &handle, QObject *parent, const QString
     : QDBusVirtualObject(parent)
     , m_data(data)
     , m_portalName(portalName)
+    , m_path(handle.path())
 {
     auto sessionBus = QDBusConnection::sessionBus();
-    if (sessionBus.registerVirtualObject(handle.path(), this, QDBusConnection::VirtualObjectRegisterOption::SubPath)) {
-        connect(this, &Request2::closeRequested, this, [this, handle]() {
-            QDBusConnection::sessionBus().unregisterObject(handle.path());
+    if (sessionBus.registerVirtualObject(m_path, this, QDBusConnection::VirtualObjectRegisterOption::SubPath)) {
+        connect(this, &Request2::closeRequested, this, [this]() {
             deleteLater();
         });
     } else {
         qCDebug(PORTAL_COMMON) << sessionBus.lastError().message();
-        qCDebug(PORTAL_COMMON) << "Failed to register request object for" << handle.path();
+        qCDebug(PORTAL_COMMON) << "Failed to register request object for" << m_path;
         deleteLater();
     }
+}
+
+Request2::~Request2()
+{
+    QDBusConnection::sessionBus().unregisterObject(m_path);
 }
 
 bool Request2::handleMessage(const QDBusMessage &message, const QDBusConnection &connection)

--- a/src/wayland/request2.h
+++ b/src/wayland/request2.h
@@ -21,6 +21,7 @@ class Request2 : public QDBusVirtualObject
     Q_OBJECT
 public:
     explicit Request2(const QDBusObjectPath &handle, QObject *parent = nullptr, const QString &portalName = QString(), const QVariant &data = QVariant());
+    ~Request2() override;
 
     bool handleMessage(const QDBusMessage &message, const QDBusConnection &connection) override;
     QString introspect(const QString &path) const override;
@@ -47,4 +48,5 @@ Q_SIGNALS:
 private:
     const QVariant m_data;
     const QString m_portalName;
+    const QString m_path;
 };

--- a/src/wayland/screenshotportal.cpp
+++ b/src/wayland/screenshotportal.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -7,17 +7,20 @@
 #include "protocols/treelandcapture.h"
 #include "loggings.h"
 #include "dbushelpers.h"
+#include "request2.h"
 
 #include <QApplication>
+#include <QDateTime>
 #include <QScreen>
 #include <QPainter>
 #include <QDir>
 #include <QRegion>
 #include <QStandardPaths>
+#include <QEventLoop>
+#include <QPointer>
 
 #include <private/qwaylandscreen_p.h>
 
-Q_LOGGING_CATEGORY(portalWayland, "dde.portal.wayland");
 struct ScreenCaptureInfo {
     QtWaylandClient::QWaylandScreen *screen {nullptr};
     QPointer<ScreenCopyFrame> capturedFrame {nullptr};
@@ -25,7 +28,7 @@ struct ScreenCaptureInfo {
     QtWayland::zwlr_screencopy_frame_v1::flags flags;
 };
 
-static void destroyScreenCaptureInfo(std::list<std::shared_ptr<ScreenCaptureInfo>> captureList)
+static void destroyScreenCaptureInfo(const std::list<std::shared_ptr<ScreenCaptureInfo>> &captureList)
 {
     for (const auto &info : std::as_const(captureList)) {
         if (info->shmBuffer) {
@@ -68,6 +71,15 @@ QString ScreenshotPortalWayland::fullScreenShot()
     QEventLoop eventLoop;
     QRegion outputRegion;
     QImage::Format formatLast;
+
+    if (m_currentScreenshotRequest) {
+        connect(m_currentScreenshotRequest, &Request2::closeRequested, &eventLoop, [this, &eventLoop, &formatLast] {
+            m_currentScreenshotCancelled = true;
+            formatLast = QImage::Format_ARGB32_Premultiplied;
+            eventLoop.quit();
+        });
+    }
+
     // Capture each output
     for (auto screen : waylandDisplay()->screens()) {
         auto info = std::make_shared<ScreenCaptureInfo>();
@@ -118,6 +130,10 @@ QString ScreenshotPortalWayland::fullScreenShot()
         });
     }
     eventLoop.exec();
+    if (m_currentScreenshotCancelled) {
+        destroyScreenCaptureInfo(captureList);
+        return "";
+    }
     // Cat them according to layout
     QImage image(outputRegion.boundingRect().size(), formatLast);
     QPainter p(&image);
@@ -130,7 +146,7 @@ QString ScreenshotPortalWayland::fullScreenShot()
             sourceRect.moveTo(sourceRect.topLeft() - info->screen->geometry().topLeft());
             p.drawImage(targetRect, *info->shmBuffer->image(), sourceRect);
         } else {
-            qCWarning(portalWayland) << "image is null!!!";
+            qCWarning(SCREESHOT) << "image is null!!!";
         }
     }
     static const char *SaveFormat = "PNG";
@@ -151,6 +167,7 @@ QString ScreenshotPortalWayland::captureInteractively()
 {
     auto captureManager = context()->treelandCaptureManager();
     auto captureContext = captureManager->getContext();
+    bool sourceFailed = false;
     if (!captureContext) {
         return "";
     }
@@ -162,7 +179,21 @@ QString ScreenshotPortalWayland::captureInteractively()
                                  ,nullptr);
     QEventLoop loop;
     connect(captureContext, &TreeLandCaptureContext::sourceReady, &loop, &QEventLoop::quit);
+    connect(captureContext, &TreeLandCaptureContext::sourceFailed, &loop, [&] {
+        sourceFailed = true;
+        loop.quit();
+    });
+    if (m_currentScreenshotRequest) {
+        connect(m_currentScreenshotRequest, &Request2::closeRequested, &loop, [this, &loop] {
+            m_currentScreenshotCancelled = true;
+            loop.quit();
+        });
+    }
     loop.exec();
+    if (m_currentScreenshotCancelled || sourceFailed) {
+        captureManager->releaseCaptureContext(captureContext);
+        return "";
+    }
     auto frame = captureContext->frame();
     QImage result;
     connect(frame, &TreeLandCaptureFrame::ready, this, [this, &result, &loop](QImage image) {
@@ -170,8 +201,15 @@ QString ScreenshotPortalWayland::captureInteractively()
         loop.quit();
     });
     connect(frame, &TreeLandCaptureFrame::failed, &loop, &QEventLoop::quit);
+    if (m_currentScreenshotRequest) {
+        connect(m_currentScreenshotRequest, &Request2::closeRequested, &loop, [this, &loop] {
+            m_currentScreenshotCancelled = true;
+            loop.quit();
+        });
+    }
     loop.exec();
-    if (result.isNull()) return "";
+    captureManager->releaseCaptureContext(captureContext);
+    if (m_currentScreenshotCancelled || result.isNull()) return "";
     auto saveBasePath = QStandardPaths::writableLocation(QStandardPaths::PicturesLocation);
     QDir saveBaseDir(saveBasePath);
     if (!saveBaseDir.exists()) return "";
@@ -189,6 +227,18 @@ uint ScreenshotPortalWayland::Screenshot(const QDBusObjectPath &handle,
                                   const QVariantMap &options,
                                   QVariantMap &results)
 {
+    uint response = PortalResponse::Success;
+    QPointer<Request2> request;
+
+    if (m_screenshotInProgress) {
+        qCWarning(SCREESHOT) << "Rejecting concurrent screenshot request";
+        return PortalResponse::OtherError;
+    }
+    m_screenshotInProgress = true;
+    m_currentScreenshotCancelled = false;
+
+    request = new Request2(handle, this, QStringLiteral("Screenshot"));
+    m_currentScreenshotRequest = request;
     if (options["modal"].toBool()) {
         // TODO if modal, we should block parent_window
     }
@@ -199,8 +249,15 @@ uint ScreenshotPortalWayland::Screenshot(const QDBusObjectPath &handle,
         filePath = fullScreenShot();
     }
     if (filePath.isEmpty()) {
-        return 1;
+        response = m_currentScreenshotCancelled ? PortalResponse::Cancelled :
+                               PortalResponse::OtherError;
+    } else {
+        results.insert(QStringLiteral("uri"), QUrl::fromLocalFile(filePath).toString(QUrl::FullyEncoded));
     }
-    results.insert(QStringLiteral("uri"), QUrl::fromLocalFile(filePath).toString(QUrl::FullyEncoded));
-    return 0;
+    if (request)
+        delete request.data();
+    m_currentScreenshotRequest.clear();
+    m_currentScreenshotCancelled = false;
+    m_screenshotInProgress = false;
+    return response;
 }

--- a/src/wayland/screenshotportal.cpp
+++ b/src/wayland/screenshotportal.cpp
@@ -18,6 +18,7 @@
 #include <QStandardPaths>
 #include <QEventLoop>
 #include <QPointer>
+#include <QScopeGuard>
 
 #include <private/qwaylandscreen_p.h>
 
@@ -26,6 +27,8 @@ struct ScreenCaptureInfo {
     QPointer<ScreenCopyFrame> capturedFrame {nullptr};
     QtWaylandClient::QWaylandShmBuffer *shmBuffer {nullptr};
     QtWayland::zwlr_screencopy_frame_v1::flags flags;
+    bool failed {false};
+    bool finished {false};
 };
 
 static void destroyScreenCaptureInfo(const std::list<std::shared_ptr<ScreenCaptureInfo>> &captureList)
@@ -39,6 +42,16 @@ static void destroyScreenCaptureInfo(const std::list<std::shared_ptr<ScreenCaptu
             delete info->capturedFrame;
         }
     }
+}
+
+static PortalResponse::Response responseFromSourceFailure(uint32_t reason)
+{
+    using CaptureContext = QtWayland::treeland_capture_context_v1;
+    if (reason == CaptureContext::source_failure_user_cancel) {
+        return PortalResponse::Cancelled;
+    }
+
+    return PortalResponse::OtherError;
 }
 
 ScreenshotPortalWayland::ScreenshotPortalWayland(PortalWaylandContext *context)
@@ -63,41 +76,70 @@ uint ScreenshotPortalWayland::PickColor(const QDBusObjectPath &handle,
     return PortalResponse::Cancelled;
 }
 
-QString ScreenshotPortalWayland::fullScreenShot()
+ScreenshotPortalWayland::CaptureResult ScreenshotPortalWayland::fullScreenShot()
 {
     std::list<std::shared_ptr<ScreenCaptureInfo>> captureList;
+    const auto cleanup = qScopeGuard([&captureList] {
+        destroyScreenCaptureInfo(captureList);
+    });
     int pendingCapture = 0;
     auto screenCopyManager = context()->screenCopyManager();
+    if (!screenCopyManager || !screenCopyManager->isActive()) {
+        qCWarning(SCREESHOT) << "Screen copy manager is not active";
+        return {PortalResponse::OtherError, QString()};
+    }
+
+    const auto screens = waylandDisplay()->screens();
+    if (screens.isEmpty()) {
+        qCWarning(SCREESHOT) << "No Wayland screens available for screenshot";
+        return {PortalResponse::OtherError, QString()};
+    }
+
     QEventLoop eventLoop;
     QRegion outputRegion;
-    QImage::Format formatLast;
 
     if (m_currentScreenshotRequest) {
-        connect(m_currentScreenshotRequest, &Request2::closeRequested, &eventLoop, [this, &eventLoop, &formatLast] {
+        connect(m_currentScreenshotRequest, &Request2::closeRequested, &eventLoop, [this, &eventLoop] {
             m_currentScreenshotCancelled = true;
-            formatLast = QImage::Format_ARGB32_Premultiplied;
             eventLoop.quit();
         });
     }
 
+    auto finishCapture = [&pendingCapture, &eventLoop](const std::shared_ptr<ScreenCaptureInfo> &info, bool failed) {
+        if (info->finished) {
+            return;
+        }
+
+        info->failed = failed;
+        info->finished = true;
+        if (--pendingCapture == 0) {
+            eventLoop.quit();
+        }
+    };
+
     // Capture each output
-    for (auto screen : waylandDisplay()->screens()) {
+    for (auto screen : screens) {
         auto info = std::make_shared<ScreenCaptureInfo>();
         outputRegion += screen->geometry();
         auto output = screen->output();
         info->capturedFrame = screenCopyManager->captureOutput(false, output);
+        if (!info->capturedFrame || !info->capturedFrame->isInitialized()) {
+            qCWarning(SCREESHOT) << "Failed to create screencopy frame for output" << screen->name();
+            return {PortalResponse::OtherError, QString()};
+        }
         info->screen = screen;
         ++pendingCapture;
         captureList.push_back(info);
         connect(info->capturedFrame, &ScreenCopyFrame::buffer, this,
-                [info](uint32_t format, uint32_t width, uint32_t height, uint32_t stride){
+                [info, &finishCapture](uint32_t format, uint32_t width, uint32_t height, uint32_t stride){
                     // Create a new wl_buffer for reception
                     // For some reason, Qt regards stride == width * 4, and it creates buffer likewise, we must check this
                     if (stride != width * 4) {
-                        qCDebug(SCREESHOT)
-                        << "Receive a buffer format which is not compatible with QWaylandShmBuffer."
-                        << "format:" << format << "width:" << width << "height:" << height
-                        << "stride:" << stride;
+                        qCWarning(SCREESHOT)
+                                << "Receive a buffer format which is not compatible with QWaylandShmBuffer."
+                                << "format:" << format << "width:" << width << "height:" << height
+                                << "stride:" << stride;
+                        finishCapture(info, true);
                         return;
                     }
                     if (info->shmBuffer)
@@ -114,36 +156,52 @@ QString ScreenshotPortalWayland::fullScreenShot()
                     info->flags = static_cast<QtWayland::zwlr_screencopy_frame_v1::flags>(flags);
                 });
         connect(info->capturedFrame, &ScreenCopyFrame::ready, this,
-                [info, &pendingCapture, &eventLoop, &formatLast](uint32_t tv_sec_hi, uint32_t tv_sec_lo, uint32_t tv_nsec) {
+                [info, &finishCapture](uint32_t tv_sec_hi, uint32_t tv_sec_lo, uint32_t tv_nsec) {
                     Q_UNUSED(tv_sec_hi);
                     Q_UNUSED(tv_sec_lo);
                     Q_UNUSED(tv_nsec);
-                    formatLast = info->shmBuffer->image()->format();
-                    if (--pendingCapture == 0) {
-                        eventLoop.quit();
+                    auto image = info->shmBuffer ? info->shmBuffer->image() : nullptr;
+                    if (!image || image->isNull()) {
+                        qCWarning(SCREESHOT) << "Screencopy frame is ready without a valid image";
+                        finishCapture(info, true);
+                        return;
                     }
+                    finishCapture(info, false);
                 });
-        connect(info->capturedFrame, &ScreenCopyFrame::failed, this, [&pendingCapture, &eventLoop]{
-            if (--pendingCapture == 0) {
-                eventLoop.quit();
-            }
+        connect(info->capturedFrame, &ScreenCopyFrame::failed, this, [info, &finishCapture]{
+            qCWarning(SCREESHOT) << "Screencopy frame failed";
+            finishCapture(info, true);
         });
     }
+
     eventLoop.exec();
     if (m_currentScreenshotCancelled) {
-        destroyScreenCaptureInfo(captureList);
-        return "";
+        return {PortalResponse::Cancelled, QString()};
     }
+    if (outputRegion.isEmpty()) {
+        qCWarning(SCREESHOT) << "Captured output region is empty";
+        return {PortalResponse::OtherError, QString()};
+    }
+    for (const auto &info : std::as_const(captureList)) {
+        auto image = info->shmBuffer ? info->shmBuffer->image() : nullptr;
+        if (info->failed || !image || image->isNull()) {
+            qCWarning(SCREESHOT) << "Unable to compose screenshot because an output image is invalid";
+            return {PortalResponse::OtherError, QString()};
+        }
+    }
+
     // Cat them according to layout
-    QImage image(outputRegion.boundingRect().size(), formatLast);
+    const QRect boundingRect = outputRegion.boundingRect();
+    QImage image(boundingRect.size(), QImage::Format_ARGB32_Premultiplied);
+    image.fill(Qt::transparent);
     QPainter p(&image);
     p.setRenderHint(QPainter::Antialiasing);
     for (const auto &info : std::as_const(captureList)) {
         if (info->shmBuffer) {
-            QRect targetRect = info->screen->geometry();
+            QRect targetRect = info->screen->geometry().translated(-boundingRect.topLeft());
             // Convert to screen image local coordinates
             auto sourceRect = targetRect;
-            sourceRect.moveTo(sourceRect.topLeft() - info->screen->geometry().topLeft());
+            sourceRect.moveTo(QPoint(0, 0));
             p.drawImage(targetRect, *info->shmBuffer->image(), sourceRect);
         } else {
             qCWarning(SCREESHOT) << "image is null!!!";
@@ -152,24 +210,49 @@ QString ScreenshotPortalWayland::fullScreenShot()
     static const char *SaveFormat = "PNG";
     auto saveBasePath = QStandardPaths::writableLocation(QStandardPaths::PicturesLocation);
     QDir saveBaseDir(saveBasePath);
-    if (!saveBaseDir.exists()) return "";
+    if (!saveBaseDir.exists()) return {PortalResponse::OtherError, QString()};
     QString picName = "portal screenshot - " + QDateTime::currentDateTime().toString() + ".png";
     if (image.save(saveBaseDir.absoluteFilePath(picName), SaveFormat)) {
-        destroyScreenCaptureInfo(captureList);
-        return saveBaseDir.absoluteFilePath(picName);
+        return {PortalResponse::Success, saveBaseDir.absoluteFilePath(picName)};
     } else {
-        destroyScreenCaptureInfo(captureList);
-        return "";
+        return {PortalResponse::OtherError, QString()};
     }
 }
 
-QString ScreenshotPortalWayland::captureInteractively()
+ScreenshotPortalWayland::CaptureResult ScreenshotPortalWayland::captureInteractively()
 {
     auto captureManager = context()->treelandCaptureManager();
+    if (!captureManager || !captureManager->isActive()) {
+        qCWarning(SCREESHOT) << "Treeland capture manager is not active";
+        return {PortalResponse::OtherError, QString()};
+    }
+
     auto captureContext = captureManager->getContext();
-    bool sourceFailed = false;
     if (!captureContext) {
-        return "";
+        return {PortalResponse::OtherError, QString()};
+    }
+    const auto releaseContext = qScopeGuard([captureManager, captureContext] {
+        if (captureManager && captureContext) {
+            captureManager->releaseCaptureContext(captureContext);
+        }
+    });
+
+    QEventLoop loop;
+    PortalResponse::Response sourceResponse = PortalResponse::OtherError;
+    connect(captureContext, &TreeLandCaptureContext::sourceReady, &loop, [&] {
+        sourceResponse = PortalResponse::Success;
+        loop.quit();
+    });
+    connect(captureContext, &TreeLandCaptureContext::sourceFailed, &loop, [&](uint32_t reason) {
+        qCWarning(SCREESHOT) << "Treeland source selection failed with reason" << reason;
+        sourceResponse = responseFromSourceFailure(reason);
+        loop.quit();
+    });
+    if (m_currentScreenshotRequest) {
+        connect(m_currentScreenshotRequest, &Request2::closeRequested, &loop, [this, &loop] {
+            m_currentScreenshotCancelled = true;
+            loop.quit();
+        });
     }
     captureContext->selectSource(QtWayland::treeland_capture_context_v1::source_type_output
                                          | QtWayland::treeland_capture_context_v1::source_type_window
@@ -177,30 +260,32 @@ QString ScreenshotPortalWayland::captureInteractively()
                                  ,true
                                  , false
                                  ,nullptr);
-    QEventLoop loop;
-    connect(captureContext, &TreeLandCaptureContext::sourceReady, &loop, &QEventLoop::quit);
-    connect(captureContext, &TreeLandCaptureContext::sourceFailed, &loop, [&] {
-        sourceFailed = true;
-        loop.quit();
-    });
-    if (m_currentScreenshotRequest) {
-        connect(m_currentScreenshotRequest, &Request2::closeRequested, &loop, [this, &loop] {
-            m_currentScreenshotCancelled = true;
-            loop.quit();
-        });
-    }
     loop.exec();
-    if (m_currentScreenshotCancelled || sourceFailed) {
-        captureManager->releaseCaptureContext(captureContext);
-        return "";
+    if (m_currentScreenshotCancelled) {
+        return {PortalResponse::Cancelled, QString()};
     }
+    if (sourceResponse != PortalResponse::Success) {
+        return {sourceResponse, QString()};
+    }
+
     auto frame = captureContext->frame();
+    if (!frame || !frame->isInitialized()) {
+        qCWarning(SCREESHOT) << "Failed to create Treeland capture frame";
+        return {PortalResponse::OtherError, QString()};
+    }
+
     QImage result;
-    connect(frame, &TreeLandCaptureFrame::ready, this, [this, &result, &loop](QImage image) {
+    PortalResponse::Response frameResponse = PortalResponse::OtherError;
+    connect(frame, &TreeLandCaptureFrame::ready, this, [this, &result, &frameResponse, &loop](QImage image) {
         result = image;
+        frameResponse = PortalResponse::Success;
         loop.quit();
     });
-    connect(frame, &TreeLandCaptureFrame::failed, &loop, &QEventLoop::quit);
+    connect(frame, &TreeLandCaptureFrame::failed, &loop, [&] {
+        qCWarning(SCREESHOT) << "Treeland capture frame failed";
+        frameResponse = PortalResponse::OtherError;
+        loop.quit();
+    });
     if (m_currentScreenshotRequest) {
         connect(m_currentScreenshotRequest, &Request2::closeRequested, &loop, [this, &loop] {
             m_currentScreenshotCancelled = true;
@@ -208,16 +293,21 @@ QString ScreenshotPortalWayland::captureInteractively()
         });
     }
     loop.exec();
-    captureManager->releaseCaptureContext(captureContext);
-    if (m_currentScreenshotCancelled || result.isNull()) return "";
+    if (m_currentScreenshotCancelled) {
+        return {PortalResponse::Cancelled, QString()};
+    }
+    if (frameResponse != PortalResponse::Success) {
+        return {frameResponse, QString()};
+    }
+    if (result.isNull()) return {PortalResponse::OtherError, QString()};
     auto saveBasePath = QStandardPaths::writableLocation(QStandardPaths::PicturesLocation);
     QDir saveBaseDir(saveBasePath);
-    if (!saveBaseDir.exists()) return "";
+    if (!saveBaseDir.exists()) return {PortalResponse::OtherError, QString()};
     QString picName = "portal screenshot - " + QDateTime::currentDateTime().toString() + ".png";
     if (result.save(saveBaseDir.absoluteFilePath(picName), "PNG")) {
-        return saveBaseDir.absoluteFilePath(picName);
+        return {PortalResponse::Success, saveBaseDir.absoluteFilePath(picName)};
     } else {
-        return "";
+        return {PortalResponse::OtherError, QString()};
     }
 }
 
@@ -228,7 +318,6 @@ uint ScreenshotPortalWayland::Screenshot(const QDBusObjectPath &handle,
                                   QVariantMap &results)
 {
     uint response = PortalResponse::Success;
-    QPointer<Request2> request;
 
     if (m_screenshotInProgress) {
         qCWarning(SCREESHOT) << "Rejecting concurrent screenshot request";
@@ -237,27 +326,34 @@ uint ScreenshotPortalWayland::Screenshot(const QDBusObjectPath &handle,
     m_screenshotInProgress = true;
     m_currentScreenshotCancelled = false;
 
-    request = new Request2(handle, this, QStringLiteral("Screenshot"));
-    m_currentScreenshotRequest = request;
+    m_currentScreenshotRequest = new Request2(handle, this, QStringLiteral("Screenshot"));
+    const auto cleanup = qScopeGuard([this] {
+        if (m_currentScreenshotRequest) {
+            m_currentScreenshotRequest->deleteLater();
+        }
+        m_currentScreenshotRequest.clear();
+        m_currentScreenshotCancelled = false;
+        m_screenshotInProgress = false;
+    });
+
     if (options["modal"].toBool()) {
         // TODO if modal, we should block parent_window
     }
-    QString filePath;
+    CaptureResult captureResult;
     if (options["interactive"].toBool()) {
-        filePath = captureInteractively();
+        captureResult = captureInteractively();
     } else {
-        filePath = fullScreenShot();
+        captureResult = fullScreenShot();
     }
-    if (filePath.isEmpty()) {
-        response = m_currentScreenshotCancelled ? PortalResponse::Cancelled :
-                               PortalResponse::OtherError;
+    response = captureResult.response;
+    if (response == PortalResponse::Success && captureResult.filePath.isEmpty()) {
+        response = PortalResponse::OtherError;
+    }
+
+    if (response == PortalResponse::Success) {
+        results.insert(QStringLiteral("uri"), QUrl::fromLocalFile(captureResult.filePath).toString(QUrl::FullyEncoded));
     } else {
-        results.insert(QStringLiteral("uri"), QUrl::fromLocalFile(filePath).toString(QUrl::FullyEncoded));
+        results.clear();
     }
-    if (request)
-        delete request.data();
-    m_currentScreenshotRequest.clear();
-    m_currentScreenshotCancelled = false;
-    m_screenshotInProgress = false;
     return response;
 }

--- a/src/wayland/screenshotportal.h
+++ b/src/wayland/screenshotportal.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -8,6 +8,9 @@
 
 #include <QDBusObjectPath>
 #include <QObject>
+#include <QPointer>
+
+class Request2;
 
 class ScreenshotPortalWayland : public AbstractWaylandPortal
 {
@@ -31,4 +34,9 @@ public Q_SLOTS:
                     const QString &parent_window,
                     const QVariantMap &options,
                     QVariantMap &results);
+
+private:
+    QPointer<Request2> m_currentScreenshotRequest;
+    bool m_currentScreenshotCancelled = false;
+    bool m_screenshotInProgress = false;
 };

--- a/src/wayland/screenshotportal.h
+++ b/src/wayland/screenshotportal.h
@@ -5,10 +5,12 @@
 #pragma once
 
 #include "abstractwaylandportal.h"
+#include "dbushelpers.h"
 
 #include <QDBusObjectPath>
 #include <QObject>
 #include <QPointer>
+#include <QString>
 
 class Request2;
 
@@ -19,9 +21,6 @@ class ScreenshotPortalWayland : public AbstractWaylandPortal
 
 public:
     ScreenshotPortalWayland(PortalWaylandContext *context);
-
-    QString fullScreenShot();
-    QString captureInteractively();
 
 public Q_SLOTS:
     uint PickColor(const QDBusObjectPath &handle,
@@ -36,6 +35,15 @@ public Q_SLOTS:
                     QVariantMap &results);
 
 private:
+    struct CaptureResult
+    {
+        PortalResponse::Response response = PortalResponse::OtherError;
+        QString filePath;
+    };
+
+    CaptureResult fullScreenShot();
+    CaptureResult captureInteractively();
+
     QPointer<Request2> m_currentScreenshotRequest;
     bool m_currentScreenshotCancelled = false;
     bool m_screenshotInProgress = false;


### PR DESCRIPTION
Body:
## Summary

This PR improves the Wayland Screenshot portal backend so screenshot requests can be cancelled cleanly and fullscreen screencopy capture no longer gets stuck waiting on incomplete compositor callbacks.

It also keeps the fullscreen screenshot composition compatible with fractional scaling by composing output images in physical pixel coordinates.

## Changes

- Register a backend `org.freedesktop.impl.portal.Request` object for Screenshot requests.
- Handle `Request.Close` and propagate cancellation into fullscreen and interactive screenshot waits.
- Unregister `Request2` objects on destruction to avoid stale request objects on D-Bus.
- Reject concurrent Screenshot requests to avoid stacked nested capture loops.
- Add a bounded timeout for fullscreen screencopy waits.
- Wait for screencopy `buffer_done` before issuing `copy()`.
- Track wl_shm/dmabuf buffer state and fail deterministically if no compatible wl_shm buffer is available.
- Destroy pending screencopy frame objects during cleanup.
- Preserve full-resolution screenshots under fractional scaling by composing captured output buffers in physical pixel coordinates.

## Why

Some clients may close or abandon Screenshot requests while the backend is still blocked in a nested wait loop. Without a backend Request object and cancellation handling, the portal backend can continue waiting until compositor callbacks arrive, or remain stuck if they never do.

Additionally, issuing screencopy `copy()` too early or ignoring incompatible buffer layouts can leave fullscreen screenshots pending until timeout.

This makes Screenshot behavior more deterministic and prevents portal screenshot requests from lingering or blocking subsequent screenshot attempts.

## Testing

- Verified with Xwayland clients using the Screenshot portal path.
- Verified repeated screenshot attempts no longer leave stale portal requests behind.
- Verified fullscreen screenshots retain physical output resolution under fractional scaling.

Build/runtime validation should be performed by the package maintainer.