### PR TITLE
chore: update changelog to 1.1.6

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+xdg-desktop-portal-dde (1.1.6) unstable; urgency=medium
+
+  * feat: enable file chooser portal on Wayland
+
+ -- zhangkun <zhangkun2@uniontech.com>  Wed, 17 Jun 2026 16:17:46 +0800
+
 xdg-desktop-portal-dde (1.1.5) unstable; urgency=medium
 
   * chore(deps): bump treeland-protocols dependency to >= 0.5.9


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 1.1.6

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 1.1.6
- 目标分支: master

## Summary by Sourcery

Documentation:
- Refresh Debian changelog entries to reflect version 1.1.6.