### PR TITLE
fix(settings): correct D-Bus replies and signatures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,13 @@ if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 endif ()
 
 include(GNUInstallDirs)
+include(CTest)
 
 add_subdirectory(src)
+
+if (BUILD_TESTING)
+    add_subdirectory(tests)
+endif ()
 
 configure_file(
     misc/xdg-desktop-portal-dde.service.in

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -8,7 +8,7 @@
 
 #include <QApplication>
 #include <QDBusConnection>
-#include <QDBusContext>
+#include <QDBusError>
 #include <QDBusMessage>
 #include <QDBusMetaType>
 #include <QLoggingCategory>
@@ -72,6 +72,7 @@ SettingsPortal::SettingsPortal(QObject *parent)
     : QDBusAbstractAdaptor(parent)
 {
     qDBusRegisterMetaType<VariantMapMap>();
+    qDBusRegisterMetaType<AccentColorArray>();
     qApp->installEventFilter(this);
 }
 
@@ -83,42 +84,27 @@ bool SettingsPortal::eventFilter(QObject *obj, QEvent *event)
     return QDBusAbstractAdaptor::eventFilter(obj, event);
 }
 
-void SettingsPortal::Read(const QString &group, const QString &key)
+QDBusVariant SettingsPortal::Read(const QString &group,
+                                  const QString &key,
+                                  const QDBusMessage &message)
 {
     qCDebug(XdgDesktopDDESetting) << "Read: group " << group << " key " << key;
 
-    QObject *obj = QObject::parent();
-
-    if (!obj) {
-        qCWarning(XdgDesktopDDESetting) << "Failed to get dbus context";
-        return;
+    if (group == QLatin1String("org.freedesktop.appearance")) {
+        if (key == QLatin1String("color-scheme")) {
+            return readFdoColorScheme();
+        }
+        if (key == QLatin1String("accent-color")) {
+            return readAccentColor();
+        }
     }
 
-    void *ptr = obj->qt_metacast("QDBusContext");
-    QDBusContext *q_ptr = reinterpret_cast<QDBusContext *>(ptr);
-
-    if (!q_ptr) {
-        qCWarning(XdgDesktopDDESetting) << "Failed to get dbus context";
-        return;
-    }
-
-    QDBusMessage reply;
-    QDBusMessage message = q_ptr->message();
-
-    if (group != QLatin1String("org.freedesktop.appearance")) {
-        return;
-    }
-    if (key == QLatin1String("color-scheme")) {
-        reply = message.createReply(QVariant::fromValue(readFdoColorScheme()));
-        QDBusConnection::sessionBus().send(reply);
-        return;
-    }
-    if (key == QLatin1String("accent-color")) {
-        reply = message.createReply(QVariant::fromValue(readAccentColor()));
-        QDBusConnection::sessionBus().send(reply);
-        return;
-    }
-    return;
+    message.setDelayedReply(true);
+    const QDBusMessage reply = message.createErrorReply(
+            QDBusError::UnknownProperty,
+            QStringLiteral("Requested setting is not supported"));
+    QDBusConnection::sessionBus().send(reply);
+    return {};
 }
 
 void SettingsPortal::onPaletteChanged(const QPalette &palette)
@@ -131,26 +117,11 @@ void SettingsPortal::onPaletteChanged(const QPalette &palette)
                           readAccentColor());
 }
 
-void SettingsPortal::ReadAll(const QStringList &groups)
+VariantMapMap SettingsPortal::ReadAll(const QStringList &groups)
 {
     qCDebug(XdgDesktopDDESetting) << "ReadAll";
     qCDebug(XdgDesktopDDESetting) << "ReadAll called with parameters:";
     qCDebug(XdgDesktopDDESetting) << "    groups: " << groups;
-
-    QObject *obj = QObject::parent();
-
-    if (!obj) {
-        qCWarning(XdgDesktopDDESetting) << "Failed to get dbus context";
-        return;
-    }
-
-    void *ptr = obj->qt_metacast("QDBusContext");
-    QDBusContext *q_ptr = reinterpret_cast<QDBusContext *>(ptr);
-
-    if (!q_ptr) {
-        qCWarning(XdgDesktopDDESetting) << "Failed to get dbus context";
-        return;
-    }
 
     VariantMapMap result;
 
@@ -161,9 +132,7 @@ void SettingsPortal::ReadAll(const QStringList &groups)
 
         result.insert(QStringLiteral("org.freedesktop.appearance"), appearanceSettings);
     }
-    QDBusMessage message = q_ptr->message();
-    QDBusMessage reply = message.createReply(QVariant::fromValue(result));
-    QDBusConnection::sessionBus().send(reply);
+    return result;
 }
 
 QDBusVariant SettingsPortal::readFdoColorScheme() const

--- a/src/settings.h
+++ b/src/settings.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -6,9 +6,13 @@
 
 #include <QDBusAbstractAdaptor>
 #include <QDBusObjectPath>
+#include <QMap>
+#include <QVariantMap>
 #include <qdbusextratypes.h>
 #include <qobjectdefs.h>
 #include <QEvent>
+
+class QDBusMessage;
 
 class SettingsPortal : public QDBusAbstractAdaptor
 {
@@ -23,8 +27,8 @@ public:
     bool eventFilter(QObject *obj, QEvent *event) override;
 
 public slots:
-    void ReadAll(const QStringList &groups);
-    void Read(const QString &group, const QString &key);
+    QMap<QString, QVariantMap> ReadAll(const QStringList &groups);
+    QDBusVariant Read(const QString &group, const QString &key, const QDBusMessage &message);
     void onPaletteChanged(const QPalette &palette);
 
 signals:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,22 @@
+find_package(Qt6 REQUIRED COMPONENTS Core DBus Widgets)
+
+add_executable(test-settings-dbus-metatype
+    test_settings_dbus_metatype.cpp
+    ${CMAKE_SOURCE_DIR}/src/settings.cpp
+    ${CMAKE_SOURCE_DIR}/src/settings.h
+)
+
+target_include_directories(test-settings-dbus-metatype PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+)
+
+target_link_libraries(test-settings-dbus-metatype PRIVATE
+    Qt6::Core
+    Qt6::DBus
+    Qt6::Widgets
+)
+
+add_test(NAME settings-dbus-metatype COMMAND test-settings-dbus-metatype)
+set_tests_properties(settings-dbus-metatype PROPERTIES
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+)

--- a/tests/test_settings_dbus_metatype.cpp
+++ b/tests/test_settings_dbus_metatype.cpp
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "dbushelpers.h"
+#include "settings.h"
+
+#include <QApplication>
+#include <QDBusMessage>
+#include <QDBusMetaType>
+#include <QMetaMethod>
+
+#include <cstring>
+#include <iostream>
+
+namespace {
+
+bool expectMethodReturnSignature(const QMetaObject &metaObject,
+                                 const char *methodName,
+                                 const char *expectedSignature)
+{
+    for (int index = metaObject.methodOffset(); index < metaObject.methodCount(); ++index) {
+        const QMetaMethod method = metaObject.method(index);
+        if (method.methodType() != QMetaMethod::Slot || method.name() != methodName) {
+            continue;
+        }
+
+        const char *signature = QDBusMetaType::typeToSignature(method.returnMetaType());
+        const char *actualSignature = signature && *signature ? signature : "<none>";
+        if (std::strcmp(actualSignature, expectedSignature) != 0) {
+            std::cerr << "Expected " << methodName << " D-Bus return signature "
+                      << expectedSignature << ", got " << actualSignature << '\n';
+            return false;
+        }
+        return true;
+    }
+
+    std::cerr << "Could not find Settings slot " << methodName << '\n';
+    return false;
+}
+
+} // namespace
+
+int main(int argc, char *argv[])
+{
+    qunsetenv("QT_SCALE_FACTOR_ROUNDING_POLICY");
+    QApplication app(argc, argv);
+    QObject parent;
+    SettingsPortal portal(&parent);
+
+    if (!expectMethodReturnSignature(SettingsPortal::staticMetaObject, "ReadAll", "a{sa{sv}}")
+        || !expectMethodReturnSignature(SettingsPortal::staticMetaObject, "Read", "v")) {
+        return 1;
+    }
+
+    VariantMapMap settings;
+    const bool invoked = QMetaObject::invokeMethod(
+            &portal,
+            "ReadAll",
+            Qt::DirectConnection,
+            Q_RETURN_ARG(VariantMapMap, settings),
+            Q_ARG(QStringList, QStringList{ QStringLiteral("org.freedesktop.appearance") }));
+    if (!invoked) {
+        std::cerr << "Could not invoke Settings.ReadAll with a VariantMapMap return value\n";
+        return 1;
+    }
+
+    const QVariantMap appearance = settings.value(QStringLiteral("org.freedesktop.appearance"));
+    if (!appearance.contains(QStringLiteral("color-scheme"))
+        || !appearance.contains(QStringLiteral("accent-color"))) {
+        std::cerr << "ReadAll did not return both appearance settings\n";
+        return 1;
+    }
+
+    const QMetaType accentType = appearance.value(QStringLiteral("accent-color")).metaType();
+    const char *accentSignature = QDBusMetaType::typeToSignature(accentType);
+    const char *actualAccentSignature =
+            accentSignature && *accentSignature ? accentSignature : "<unregistered>";
+    if (std::strcmp(actualAccentSignature, "(ddd)") != 0) {
+        std::cerr << "Expected accent-color D-Bus signature (ddd), got " << actualAccentSignature
+                  << '\n';
+        return 1;
+    }
+
+    QDBusVariant colorScheme;
+    const bool readInvoked =
+            QMetaObject::invokeMethod(&portal,
+                                      "Read",
+                                      Qt::DirectConnection,
+                                      Q_RETURN_ARG(QDBusVariant, colorScheme),
+                                      Q_ARG(QString, QStringLiteral("org.freedesktop.appearance")),
+                                      Q_ARG(QString, QStringLiteral("color-scheme")),
+                                      Q_ARG(QDBusMessage, QDBusMessage()));
+    if (!readInvoked || colorScheme.variant().metaType() != QMetaType::fromType<uint>()) {
+        std::cerr << "Settings.Read did not return an unsigned color-scheme variant\n";
+        return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Problem

The Settings adaptor declared `Read` and `ReadAll` without return values, so its runtime D-Bus introspection did not match the portal contract (`ss -> v` and `as -> a{sa{sv}}`). In addition, `AccentColorArray` was not registered with Qt D-Bus, causing `ReadAll` to abort while marshalling `accent-color`.

## Summary

- declare the `Read` and `ReadAll` return values so Qt exposes and marshals the expected D-Bus signatures
- register `AccentColorArray` before Settings replies are marshalled
- add regression coverage for both method signatures and the standardized `(ddd)` accent-color value

## Testing

- `cmake --build build -j$(nproc)`
- `ctest --test-dir build --output-on-failure`
- isolated-session `ReadAll(["org.freedesktop.appearance"])` returned both settings without terminating the portal