### PR TITLE
fix(cmake): fix undefined reference errors in wayland module

### DIFF
--- a/src/wayland/CMakeLists.txt
+++ b/src/wayland/CMakeLists.txt
@@ -81,6 +81,8 @@ add_library(xdg-desktop-portal-dde-wayland SHARED
     toplevelpipewirestream.cpp
     protocols/wallpapermanagerclient.h
     protocols/wallpapermanagerclient.cpp
+    ../wallpaper.cpp
+    ../utils.cpp
 )
 
 qt6_generate_wayland_protocol_client_sources(xdg-desktop-portal-dde-wayland FILES


### PR DESCRIPTION
Add missing source files '../wallpaper.cpp' and '../utils.cpp' to src/wayland/CMakeLists.txt to fix link-time errors.

Without these sources, the wayland module targets fail to link with errors such as:
  undefined reference to `WallPaperPortal::WallPaperPortal(QObject*)`

Including both files ensures that the wallpaper management and utility symbols are properly resolved during the build.