### PR TITLE
fix(screenshot): 相对完整地修复截图问题, 并增加弹窗处理

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,6 +57,8 @@ set(SRC
     account.cpp
     access.cpp
     access.h
+    accessdialogtypes.h
+    accessdialogtypes.cpp
     globalshortcut.h
     globalshortcut.cpp
     lockdown.h

--- a/src/access.cpp
+++ b/src/access.cpp
@@ -1,34 +1,261 @@
-// Copyright (C) 2024 Wenhao Peng <pengwenhao@uniontech.com>.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
+//
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "access.h"
 
-#include <sys/types.h>
-#include <unistd.h>
-
-#include <QLoggingCategory>
-#include <QVariantMap>
-#include <QDBusMessage>
-#include <QDBusPendingReply>
-#include <QDBusConnection>
-#include <QMessageBox>
 #include "accessdialog.h"
+#include "request.h"
+#include "utils.h"
+
+#include <QDBusConnection>
+#include <QDBusMetaType>
+#include <QDialog>
+#include <QGuiApplication>
+#include <QLoggingCategory>
+#include <QTimer>
+
+#if QT_CONFIG(wayland)
+#  include <QtGui/qguiapplication_platform.h>
+#  include <wayland-client.h>
+#endif
+
+#include <cerrno>
+#include <functional>
+#include <utility>
 
 Q_LOGGING_CATEGORY(XdgDestkopDDEAccess, "xdg-dde-access")
+
+namespace
+{
+
+// Treeland keeps an unmapped toplevel's snapshot visible for its default
+// 400 ms close animation. Leave scheduling margin before allowing screencopy
+// to request its next output commit.
+constexpr int WindowWithdrawalGracePeriodMs = 500;
+
+#if QT_CONFIG(wayland)
+
+class WaylandSyncBarrier final : public QObject
+{
+public:
+    using Completion = std::function<void()>;
+
+    static void wait(wl_display *display,
+                     QObject *context,
+                     Completion completion,
+                     Completion failure)
+    {
+        auto barrier = new WaylandSyncBarrier(context, std::move(completion));
+        if (barrier->start(display)) {
+            return;
+        }
+
+        delete barrier;
+        failure();
+    }
+
+    ~WaylandSyncBarrier() override
+    {
+        if (m_callback) {
+            wl_callback_destroy(m_callback);
+        }
+    }
+
+private:
+    explicit WaylandSyncBarrier(QObject *parent, Completion completion)
+        : QObject(parent)
+        , m_completion(std::move(completion))
+    {
+    }
+
+    bool start(wl_display *display)
+    {
+        if (!display) {
+            return false;
+        }
+
+        m_callback = wl_display_sync(display);
+        if (!m_callback || wl_callback_add_listener(m_callback, &s_listener, this) < 0) {
+            return false;
+        }
+
+        // EAGAIN only means that Qt's Wayland event loop must flush again once
+        // the socket becomes writable. Other errors cannot produce a useful
+        // synchronization point, so fail closed instead of taking a screenshot
+        // while the permission dialog may still be mapped.
+        if (wl_display_flush(display) < 0 && errno != EAGAIN) {
+            qCWarning(XdgDestkopDDEAccess)
+                    << "Failed to flush the Wayland window-withdrawal barrier";
+            return false;
+        }
+        return true;
+    }
+
+    static void handleDone(void *data, wl_callback *callback, uint32_t serial)
+    {
+        Q_UNUSED(serial)
+
+        auto barrier = static_cast<WaylandSyncBarrier *>(data);
+        if (callback != barrier->m_callback) {
+            return;
+        }
+
+        wl_callback_destroy(barrier->m_callback);
+        barrier->m_callback = nullptr;
+
+        auto completion = std::move(barrier->m_completion);
+        barrier->deleteLater();
+        completion();
+    }
+
+    static const wl_callback_listener s_listener;
+
+    wl_callback *m_callback = nullptr;
+    Completion m_completion;
+};
+
+const wl_callback_listener WaylandSyncBarrier::s_listener = {
+    WaylandSyncBarrier::handleDone,
+};
+
+#endif
+
+void sendAccessReply(const QDBusMessage &message,
+                     uint response,
+                     const AccessDialogTypes::Choices &choices = {})
+{
+    QVariantMap results;
+    results.insert(QStringLiteral("choices"), QVariant::fromValue(choices));
+    const auto reply = message.createReply(
+            QVariantList{QVariant::fromValue(response), results});
+    if (!QDBusConnection::sessionBus().send(reply)) {
+        qCWarning(XdgDestkopDDEAccess) << "Failed to send access dialog response";
+    }
+}
+
+void sendAccessReplyAfterWindowWithdrawal(
+        QObject *context,
+        const QDBusMessage &message,
+        uint response,
+        const AccessDialogTypes::Choices &choices)
+{
+    // Run after the dialog's deferred deletion has completed. This makes the
+    // Wayland sync request follow the surface unmap/destruction requests on the
+    // same connection rather than merely following QDialog::finished().
+    QTimer::singleShot(0, context, [context, message, response, choices] {
+        const auto sendReply = [message, response, choices] {
+            sendAccessReply(message, response, choices);
+        };
+
+        if (QGuiApplication::platformName() != QLatin1String("wayland")) {
+            QGuiApplication::sync();
+            sendReply();
+            return;
+        }
+
+#if QT_CONFIG(wayland)
+        auto waylandApplication = qGuiApp->nativeInterface<
+                QNativeInterface::QWaylandApplication>();
+        if (!waylandApplication) {
+            qCWarning(XdgDestkopDDEAccess)
+                    << "Cannot synchronize access dialog withdrawal with Wayland";
+            sendAccessReply(message, 2);
+            return;
+        }
+
+        WaylandSyncBarrier::wait(
+                waylandApplication->display(),
+                context,
+                [context, response, sendReply] {
+                    if (response == 0) {
+                        QTimer::singleShot(
+                                WindowWithdrawalGracePeriodMs, context, sendReply);
+                    } else {
+                        sendReply();
+                    }
+                },
+                [message] {
+                    qCWarning(XdgDestkopDDEAccess)
+                            << "Cannot establish the Wayland window-withdrawal barrier";
+                    sendAccessReply(message, 2);
+                });
+#else
+        qCWarning(XdgDestkopDDEAccess)
+                << "Wayland platform detected without Wayland client support";
+        sendAccessReply(message, 2);
+#endif
+    });
+}
+
+}
 
 AccessPortal::AccessPortal(QObject *parent)
     : QDBusAbstractAdaptor(parent)
 {
-    qCDebug(XdgDestkopDDEAccess) << "access init";
+    qDBusRegisterMetaType<AccessDialogTypes::Choice>();
+    qDBusRegisterMetaType<AccessDialogTypes::Choices>();
+    qDBusRegisterMetaType<AccessDialogTypes::Option>();
+    qDBusRegisterMetaType<AccessDialogTypes::OptionList>();
+    qCDebug(XdgDestkopDDEAccess) << "Access portal initialized";
 }
 
-using AccessDialogClass = AccessDialog;
-
-uint AccessPortal::AccessDialog(
-        const QDBusObjectPath &handle, const QString &app_id, const QString &parent_window, const QString &title,
-        const QString &subtitle, const QString &body, const QVariantMap &options, QVariantMap &results)
+void AccessPortal::AccessDialog(const QDBusObjectPath &handle,
+                                const QString &app_id,
+                                const QString &parent_window,
+                                const QString &title,
+                                const QString &subtitle,
+                                const QString &body,
+                                const QVariantMap &options,
+                                const QDBusMessage &message,
+                                uint &replyResponse,
+                                QVariantMap &replyResults)
 {
-    qCDebug(XdgDestkopDDEAccess) << "request for access dialog";
-    AccessDialogClass dialog(app_id,parent_window,title,subtitle,body,options);
-    return dialog.exec();
+    Q_UNUSED(replyResponse)
+    Q_UNUSED(replyResults)
+
+    qCDebug(XdgDestkopDDEAccess) << "Access dialog requested by" << app_id
+                                 << "with handle" << handle.path();
+    message.setDelayedReply(true);
+
+    AccessDialogTypes::OptionList choices;
+    if (options.contains(QStringLiteral("choices"))) {
+        choices = qdbus_cast<AccessDialogTypes::OptionList>(
+                options.value(QStringLiteral("choices")));
+    }
+
+    auto dialog = new ::AccessDialog(title, subtitle, body, options, choices);
+    Utils::setParentWindow(dialog, parent_window);
+
+    auto request = new Request(handle, QVariant(), dialog);
+    if (!request->isRegistered()) {
+        sendAccessReply(message, 2);
+        dialog->deleteLater();
+        return;
+    }
+    connect(request, &Request::closeRequested, dialog, &QDialog::reject);
+    connect(dialog,
+            &QDialog::finished,
+            this,
+            [dialog, request, message, this](int result) {
+                request->unregister();
+                const uint response = result == QDialog::Accepted ? 0 : 1;
+                const auto selectedChoices = dialog->selectedChoices();
+
+                // QDialog::finished() is emitted after the widget is hidden, but on
+                // Wayland that does not mean the compositor has processed the unmap.
+                // Destroy the native window first and reply only after the display
+                // synchronization point acknowledges all preceding requests.
+                connect(dialog,
+                        &QObject::destroyed,
+                        this,
+                        [this, message, response, selectedChoices] {
+                            sendAccessReplyAfterWindowWithdrawal(
+                                    this, message, response, selectedChoices);
+                        });
+                dialog->hide();
+                dialog->deleteLater();
+            },
+            Qt::SingleShotConnection);
+    dialog->open();
 }

--- a/src/access.h
+++ b/src/access.h
@@ -1,9 +1,13 @@
-// Copyright (C) 2024 pengwenhao <pengwenhao@deepin.com>.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
+//
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #pragma once
 
+#include "accessdialogtypes.h"
+
 #include <QDBusAbstractAdaptor>
+#include <QDBusMessage>
 #include <QDBusObjectPath>
 
 class AccessPortal : public QDBusAbstractAdaptor
@@ -15,13 +19,15 @@ public:
     explicit AccessPortal(QObject *parent);
     ~AccessPortal() = default;
 
-public slots:
-    uint AccessDialog(const QDBusObjectPath &handle,
+public Q_SLOTS:
+    void AccessDialog(const QDBusObjectPath &handle,
                       const QString &app_id,
                       const QString &parent_window,
                       const QString &title,
                       const QString &subtitle,
                       const QString &body,
                       const QVariantMap &options,
-                      QVariantMap &results);
+                      const QDBusMessage &message,
+                      uint &replyResponse,
+                      QVariantMap &replyResults);
 };

--- a/src/accessdialog.cpp
+++ b/src/accessdialog.cpp
@@ -1,94 +1,128 @@
-// Copyright (C) 2024 Wenhao Peng <pengwenhao@uniontech.com>.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
+//
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "accessdialog.h"
-#include <QWindow>
-#include <QMessageBox>
-#include <QTimer>
-#include <QPushButton>
-// X11的声明放在下面，防止编译报错
-#include <X11/Xlib.h>
 
-AccessDialog::AccessDialog(const QString &app_id, const QString &parent_window, const QString &title, const QString &subtitle, const QString &body, const QVariantMap &options) :
-    DDialog(),
-    m_titleLabel(new QLabel(this)),
-    m_subtitleLabel(new QLabel(this)),
-    m_bodyLabel(new QLabel(this)),
-    m_countdownTimer(new QTimer(this)),
-    m_denyButton(nullptr),
-    m_remainingSeconds(15)
+#include <QCheckBox>
+#include <QComboBox>
+#include <QFormLayout>
+#include <QIcon>
+#include <QLabel>
+#include <QVBoxLayout>
+
+#include <utility>
+
+AccessDialog::AccessDialog(const QString &title,
+                           const QString &subtitle,
+                           const QString &body,
+                           const QVariantMap &options,
+                           const AccessDialogTypes::OptionList &choices,
+                           QWidget *parent)
+    : DDialog(parent)
+    , m_choices(choices)
 {
-    setAccessibleName("AccessDialog");
-    setIcon(QIcon::fromTheme("dialog-warning"));
-    setAttribute(Qt::WA_QuitOnClose);
-    // 设置tittle
-    m_titleLabel->setObjectName("TitileText");
-    m_titleLabel->setAccessibleName("TitileText");
-    addContent(m_titleLabel, Qt::AlignTop | Qt::AlignHCenter);
-    QFont font = m_titleLabel->font();
-    font.setBold(true);
-    font.setPixelSize(16);
-    m_titleLabel->setFont(font);
-    m_titleLabel->setText(title);
-    // 设置subtitle
-    m_subtitleLabel->setObjectName("SubtitleText");
-    m_subtitleLabel->setAccessibleName("SubtitleText");
-    addContent(m_subtitleLabel, Qt::AlignTop | Qt::AlignHCenter);
-    m_subtitleLabel->setText(subtitle+"\n");
-    // 设置body
-    m_bodyLabel->setObjectName("BodyText");
-    m_bodyLabel->setAccessibleName("BodyText");
-    addContent(m_bodyLabel, Qt::AlignTop | Qt::AlignHCenter);
-    m_bodyLabel->setText(body);
+    setAccessibleName(QStringLiteral("AccessDialog"));
+    setTitle(title);
+    setWordWrapTitle(true);
+    setWindowModality(options.value(QStringLiteral("modal"), true).toBool()
+                              ? Qt::WindowModal
+                              : Qt::NonModal);
+    setOnButtonClickedClose(false);
+    setCloseButtonVisible(true);
 
-    if (options.contains(QStringLiteral("modal"))) {
-        setModal(options.value(QStringLiteral("modal")).toBool());
+    const QString iconName = options.value(QStringLiteral("icon")).toString();
+    setIcon(QIcon::fromTheme(iconName.isEmpty() ? QStringLiteral("dialog-warning") : iconName));
+
+    auto content = new QWidget(this);
+    auto contentLayout = new QVBoxLayout(content);
+    contentLayout->setContentsMargins(0, 0, 0, 0);
+
+    if (!subtitle.isEmpty()) {
+        auto subtitleLabel = new QLabel(subtitle, content);
+        subtitleLabel->setObjectName(QStringLiteral("SubtitleText"));
+        subtitleLabel->setAccessibleName(QStringLiteral("SubtitleText"));
+        subtitleLabel->setTextFormat(Qt::PlainText);
+        subtitleLabel->setWordWrap(true);
+        QFont font = subtitleLabel->font();
+        font.setBold(true);
+        subtitleLabel->setFont(font);
+        contentLayout->addWidget(subtitleLabel);
     }
 
-    if (options.contains(QStringLiteral("deny_label"))) {
-        m_denyLabel = options.value(QStringLiteral("deny_label")).toString();
-    } else {
-        m_denyLabel = tr("Deny Access");
-    }
-    
-    int denyButtonIndex = addButton(tr("%1 (%2s)", "e.g. Deny Access (15s)").arg(m_denyLabel).arg(m_remainingSeconds), QMessageBox::RejectRole);
-    m_denyButton = qobject_cast<QPushButton*>(getButton(denyButtonIndex));
-    
-    // 设置定时器
-    connect(m_countdownTimer, &QTimer::timeout, this, &AccessDialog::updateDenyButtonText);
-    m_countdownTimer->start(1000); // 每秒更新一次
-
-
-    int allowButton;
-    if (options.contains(QStringLiteral("grant_label"))) {
-        addButton(options.value(QStringLiteral("grant_label")).toString(), QMessageBox::AcceptRole);
-    } else {
-        addButton(tr("Grant Access"), QMessageBox::AcceptRole);
+    if (!body.isEmpty()) {
+        auto bodyLabel = new QLabel(body, content);
+        bodyLabel->setObjectName(QStringLiteral("BodyText"));
+        bodyLabel->setAccessibleName(QStringLiteral("BodyText"));
+        bodyLabel->setTextFormat(Qt::PlainText);
+        bodyLabel->setWordWrap(true);
+        contentLayout->addWidget(bodyLabel);
     }
 
-    setWindowFlag(Qt::WindowStaysOnTopHint);
+    if (!m_choices.isEmpty()) {
+        auto choicesWidget = new QWidget(content);
+        auto choicesLayout = new QFormLayout(choicesWidget);
+        choicesLayout->setContentsMargins(0, 0, 0, 0);
+        for (const auto &option : std::as_const(m_choices)) {
+            m_selectedChoices.insert(option.id, option.initialChoiceId);
+            if (option.choices.isEmpty()) {
+                auto checkBox = new QCheckBox(option.label, choicesWidget);
+                checkBox->setChecked(option.initialChoiceId == QStringLiteral("true"));
+                connect(checkBox, &QCheckBox::toggled, this, [this, id = option.id](bool checked) {
+                    m_selectedChoices.insert(id,
+                                             checked ? QStringLiteral("true")
+                                                     : QStringLiteral("false"));
+                });
+                choicesLayout->addRow(checkBox);
+                continue;
+            }
+
+            auto comboBox = new QComboBox(choicesWidget);
+            int initialIndex = 0;
+            for (qsizetype i = 0; i < option.choices.size(); ++i) {
+                const auto &choice = option.choices.at(i);
+                comboBox->addItem(choice.value, choice.id);
+                if (choice.id == option.initialChoiceId) {
+                    initialIndex = i;
+                }
+            }
+            comboBox->setCurrentIndex(initialIndex);
+            if (!option.choices.isEmpty()) {
+                m_selectedChoices.insert(option.id, option.choices.at(initialIndex).id);
+            }
+            connect(comboBox, &QComboBox::currentIndexChanged, this,
+                    [this, comboBox, id = option.id](int index) {
+                if (index >= 0) {
+                    m_selectedChoices.insert(id, comboBox->itemData(index).toString());
+                }
+            });
+            choicesLayout->addRow(option.label, comboBox);
+        }
+        contentLayout->addWidget(choicesWidget);
+    }
+
+    addContent(content);
+
+    const QString denyLabel = options.value(QStringLiteral("deny_label"), tr("Deny")).toString();
+    const QString grantLabel = options.value(QStringLiteral("grant_label"), tr("Allow")).toString();
+    const int denyButton = addButton(denyLabel, false, DDialog::ButtonNormal);
+    const int grantButton = addButton(grantLabel, true, DDialog::ButtonRecommend);
+    connect(this, &DDialog::buttonClicked, this,
+            [this, denyButton, grantButton](int index, const QString &) {
+        if (index == grantButton) {
+            accept();
+        } else if (index == denyButton) {
+            reject();
+        }
+    });
 }
 
-AccessDialog::~AccessDialog(){
-    if (m_countdownTimer) {
-        m_countdownTimer->stop();
-    }
-}
-
-void AccessDialog::updateDenyButtonText()
+AccessDialogTypes::Choices AccessDialog::selectedChoices() const
 {
-    m_remainingSeconds--;
-    
-    if (m_remainingSeconds <= 0) {
-        m_countdownTimer->stop();
-        onTimeout();
-    } else if (m_denyButton) {
-        m_denyButton->setText(tr("%1 (%2s)", "e.g. Deny Access (15s)").arg(m_denyLabel).arg(m_remainingSeconds));
+    AccessDialogTypes::Choices result;
+    result.reserve(m_choices.size());
+    for (const auto &option : m_choices) {
+        result.append({option.id, m_selectedChoices.value(option.id, option.initialChoiceId)});
     }
-}
-
-void AccessDialog::onTimeout()
-{
-    // 倒计时结束，自动拒绝
-    reject();
+    return result;
 }

--- a/src/accessdialog.h
+++ b/src/accessdialog.h
@@ -1,37 +1,32 @@
-// Copyright (C) 2024 Wenhao Peng <pengwenhao@uniontech.com>.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
+//
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
-#ifndef XDG_DESKTOP_PORTAL_DDE_ACCESSDIALOG_H
-#define XDG_DESKTOP_PORTAL_DDE_ACCESSDIALOG_H
+#pragma once
 
-#include <ddialog.h>
-#include <DWidget>
-#include <QLabel>
-#include <QVBoxLayout>
-#include <QDialogButtonBox>
-#include <QTimer>
-#include <QPushButton>
+#include "accessdialogtypes.h"
+
+#include <DDialog>
+
+#include <QMap>
 
 DWIDGET_USE_NAMESPACE
-class LargeLabel;
 
 class AccessDialog : public DDialog
 {
     Q_OBJECT
-public:
-    explicit AccessDialog(const QString &app_id,const QString &parent_window,const QString &title,const QString &subtitle,const QString &body, const QVariantMap &options);
-    ~AccessDialog();
-private slots:
-    void updateDenyButtonText();
-    void onTimeout();
-private:
-    QLabel *m_titleLabel;
-    QLabel *m_subtitleLabel;
-    QLabel *m_bodyLabel;
-    QTimer *m_countdownTimer;
-    QPushButton *m_denyButton;
-    int m_remainingSeconds;
-    QString m_denyLabel;
-};
 
-#endif // XDG_DESKTOP_PORTAL_DDE_ACCESSDIALOG_H
+public:
+    AccessDialog(const QString &title,
+                 const QString &subtitle,
+                 const QString &body,
+                 const QVariantMap &options,
+                 const AccessDialogTypes::OptionList &choices,
+                 QWidget *parent = nullptr);
+
+    AccessDialogTypes::Choices selectedChoices() const;
+
+private:
+    AccessDialogTypes::OptionList m_choices;
+    QMap<QString, QString> m_selectedChoices;
+};

--- a/src/accessdialogtypes.cpp
+++ b/src/accessdialogtypes.cpp
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#include "accessdialogtypes.h"
+
+namespace AccessDialogTypes
+{
+
+QDBusArgument &operator<<(QDBusArgument &argument, const Choice &choice)
+{
+    argument.beginStructure();
+    argument << choice.id << choice.value;
+    argument.endStructure();
+    return argument;
+}
+
+const QDBusArgument &operator>>(const QDBusArgument &argument, Choice &choice)
+{
+    argument.beginStructure();
+    argument >> choice.id >> choice.value;
+    argument.endStructure();
+    return argument;
+}
+
+QDBusArgument &operator<<(QDBusArgument &argument, const Option &option)
+{
+    argument.beginStructure();
+    argument << option.id << option.label << option.choices << option.initialChoiceId;
+    argument.endStructure();
+    return argument;
+}
+
+const QDBusArgument &operator>>(const QDBusArgument &argument, Option &option)
+{
+    argument.beginStructure();
+    argument >> option.id >> option.label >> option.choices >> option.initialChoiceId;
+    argument.endStructure();
+    return argument;
+}
+
+}

--- a/src/accessdialogtypes.h
+++ b/src/accessdialogtypes.h
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#pragma once
+
+#include <QDBusArgument>
+#include <QList>
+#include <QString>
+
+namespace AccessDialogTypes
+{
+
+struct Choice
+{
+    QString id;
+    QString value;
+};
+using Choices = QList<Choice>;
+
+struct Option
+{
+    QString id;
+    QString label;
+    Choices choices;
+    QString initialChoiceId;
+};
+using OptionList = QList<Option>;
+
+QDBusArgument &operator<<(QDBusArgument &argument, const Choice &choice);
+const QDBusArgument &operator>>(const QDBusArgument &argument, Choice &choice);
+QDBusArgument &operator<<(QDBusArgument &argument, const Option &option);
+const QDBusArgument &operator>>(const QDBusArgument &argument, Option &option);
+
+}
+
+Q_DECLARE_METATYPE(AccessDialogTypes::Choice)
+Q_DECLARE_METATYPE(AccessDialogTypes::Choices)
+Q_DECLARE_METATYPE(AccessDialogTypes::Option)
+Q_DECLARE_METATYPE(AccessDialogTypes::OptionList)

--- a/src/request.cpp
+++ b/src/request.cpp
@@ -17,16 +17,26 @@ Request::Request(const QDBusObjectPath &handle, const QVariant &data, QObject *p
     , m_data(data)
 {
     auto sessionBus = QDBusConnection::sessionBus();
-    if (!sessionBus.registerObject(m_handle.path(), this, QDBusConnection::ExportScriptableSlots)) {
+    m_registered = sessionBus.registerObject(
+            m_handle.path(), this, QDBusConnection::ExportScriptableSlots);
+    if (!m_registered) {
         qCDebug(XdgDesktopDDERequest) << sessionBus.lastError().message();
         qCDebug(XdgDesktopDDERequest) << "Failed to register request object for" << m_handle.path();
-        deleteLater();
     }
 }
 
 Request::~Request()
 {
+    unregister();
+}
+
+void Request::unregister()
+{
+    if (!m_registered) {
+        return;
+    }
     QDBusConnection::sessionBus().unregisterObject(m_handle.path());
+    m_registered = false;
 }
 
 void Request::Close(const QDBusMessage &message)
@@ -34,6 +44,7 @@ void Request::Close(const QDBusMessage &message)
     QDBusMessage messageReply = message.createReply();
     QDBusConnection::sessionBus().send(messageReply);
 
-    emit closeRequested(m_data);
+    unregister();
+    Q_EMIT closeRequested(m_data);
     deleteLater();
 }

--- a/src/request.h
+++ b/src/request.h
@@ -19,6 +19,9 @@ public:
     Request(const QDBusObjectPath &handle, const QVariant &data, QObject *parent = nullptr);
     ~Request();
 
+    bool isRegistered() const { return m_registered; }
+    void unregister();
+
 public slots:  // DBus methods
     Q_SCRIPTABLE void Close(const QDBusMessage &message);
 
@@ -28,4 +31,5 @@ signals:
 private:
     QDBusObjectPath m_handle;
     QVariant m_data;
+    bool m_registered = false;
 };

--- a/src/screenshot.h
+++ b/src/screenshot.h
@@ -13,6 +13,7 @@ class ScreenshotPortal : public QDBusAbstractAdaptor
 {
     Q_OBJECT
     Q_CLASSINFO("D-Bus Interface", "org.freedesktop.impl.portal.Screenshot")
+    Q_PROPERTY(uint version READ version CONSTANT)
 
 public:
     struct ColorRGB
@@ -23,6 +24,8 @@ public:
     };
     explicit ScreenshotPortal(QObject *parent);
     ~ScreenshotPortal() = default;
+
+    uint version() const { return 2; }
 
 public slots:
     uint PickColor(const QDBusObjectPath &handle,

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
 #include "utils.h"
+#include "wayland/foreignparent.h"
 
 void Utils::setParentWindow(QWidget *w, const QString &parent_window)
 {
@@ -43,5 +44,7 @@ void Utils::setParentWindow(QWidget *w, const QString &parent_window)
 
 void Utils::setParentWindow(QWindow *w, const QString &parent_window)
 {
-    // TODO
+    if (parent_window.startsWith(QLatin1String("wayland:"))) {
+        WaylandForeignParent::setParent(w, parent_window.mid(8));
+    }
 }

--- a/src/wayland/CMakeLists.txt
+++ b/src/wayland/CMakeLists.txt
@@ -24,6 +24,10 @@ add_library(xdg-desktop-portal-dde-wayland SHARED
     portalwaylandcontext.cpp
     screenshotportal.h
     screenshotportal.cpp
+    screenshotimage.h
+    screenshotimage.cpp
+    foreignparent.h
+    foreignparent.cpp
     abstractwaylandportal.h
     treelandintegration.h
     treelandintegration.cpp
@@ -93,6 +97,7 @@ qt6_generate_wayland_protocol_client_sources(xdg-desktop-portal-dde-wayland FILE
     ${WAYLANDPROTOCOlS_PKGDATADIR}/staging/ext-foreign-toplevel-list/ext-foreign-toplevel-list-v1.xml
     ${WAYLANDPROTOCOlS_PKGDATADIR}/staging/ext-image-copy-capture/ext-image-copy-capture-v1.xml
     ${WAYLANDPROTOCOlS_PKGDATADIR}/staging/ext-image-capture-source/ext-image-capture-source-v1.xml
+    ${WAYLANDPROTOCOlS_PKGDATADIR}/unstable/xdg-foreign/xdg-foreign-unstable-v2.xml
     ${TREELAND_PROTOCOLS_DATA_DIR}/treeland-wallpaper-manager-unstable-v1.xml
 )
 

--- a/src/wayland/foreignparent.cpp
+++ b/src/wayland/foreignparent.cpp
@@ -1,0 +1,184 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "foreignparent.h"
+
+#include "qwayland-xdg-foreign-unstable-v2.h"
+
+#include <QGuiApplication>
+#include <QLoggingCategory>
+#include <QPointer>
+#include <QTimer>
+#include <QWindow>
+#include <qpa/qplatformnativeinterface.h>
+
+#include <private/qwaylandclientextension_p.h>
+
+#include <utility>
+
+Q_LOGGING_CATEGORY(waylandForeignParentLog, "dde.portal.wayland.foreignparent")
+
+namespace
+{
+
+class ForeignParentManager final
+    : public QWaylandClientExtensionTemplate<ForeignParentManager>
+    , public QtWayland::zxdg_importer_v2
+{
+public:
+    ForeignParentManager()
+        : QWaylandClientExtensionTemplate<ForeignParentManager>(1)
+    {
+    }
+
+    ~ForeignParentManager() override
+    {
+        if (isInitialized()) {
+            destroy();
+        }
+    }
+};
+
+class ImportedParent final : public QObject, public QtWayland::zxdg_imported_v2
+{
+public:
+    ImportedParent(struct ::zxdg_imported_v2 *object, QWindow *window, struct ::wl_surface *surface)
+        : QObject(window)
+        , QtWayland::zxdg_imported_v2(object)
+    {
+        set_parent_of(surface);
+    }
+
+    ~ImportedParent() override
+    {
+        if (isInitialized()) {
+            destroy();
+        }
+    }
+
+protected:
+    void zxdg_imported_v2_destroyed() override
+    {
+        deleteLater();
+    }
+};
+
+QPointer<ForeignParentManager> foreignParentManager()
+{
+    static QPointer<ForeignParentManager> manager;
+    if (!manager) {
+        manager = new ForeignParentManager;
+        manager->setParent(qApp);
+    }
+    return manager;
+}
+
+class ForeignParentBinding final : public QObject
+{
+public:
+    ForeignParentBinding(QWindow *window, QString handle)
+        : QObject(window)
+        , m_window(window)
+        , m_manager(foreignParentManager())
+        , m_handle(std::move(handle))
+    {
+        if (!m_manager) {
+            deleteLater();
+            return;
+        }
+
+        connect(m_window, &QWindow::visibleChanged, this, [this](bool visible) {
+            if (visible) {
+                scheduleAttempt();
+            }
+        });
+        connect(m_manager, &ForeignParentManager::activeChanged, this, [this] {
+            scheduleAttempt();
+        });
+        scheduleAttempt();
+    }
+
+private:
+    void scheduleAttempt()
+    {
+        if (m_attemptScheduled) {
+            return;
+        }
+        m_attemptScheduled = true;
+
+        // QWindow::visibleChanged(true) is emitted before the platform
+        // window's setVisible() call. Queue the attempt so Qt Wayland can
+        // create the xdg_surface and xdg_toplevel first.
+        QTimer::singleShot(0, this, [this] {
+            m_attemptScheduled = false;
+            attemptBinding();
+        });
+    }
+
+    void attemptBinding()
+    {
+        if (!m_window || !m_window->isVisible() || !m_manager || !m_manager->isActive()) {
+            return;
+        }
+
+        auto nativeInterface = qGuiApp->platformNativeInterface();
+        if (!nativeInterface) {
+            qCWarning(waylandForeignParentLog)
+                    << "No native interface is available for Wayland parent binding";
+            deleteLater();
+            return;
+        }
+
+        // A wl_surface can exist before Qt assigns it an xdg_toplevel role.
+        // Passing such a surface to zxdg_imported_v2.set_parent_of is a fatal
+        // protocol error, so verify the exact role instead of inferring it
+        // from window visibility or the existence of a wl_surface.
+        if (!nativeInterface->nativeResourceForWindow(
+                    QByteArrayLiteral("xdg_toplevel"), m_window)) {
+            qCWarning(waylandForeignParentLog)
+                    << "Portal window has no xdg_toplevel role; skipping parent binding";
+            deleteLater();
+            return;
+        }
+
+        auto surface = static_cast<struct ::wl_surface *>(
+                nativeInterface->nativeResourceForWindow(
+                        QByteArrayLiteral("surface"), m_window));
+        if (!surface) {
+            qCWarning(waylandForeignParentLog)
+                    << "No Wayland surface is available for portal dialog";
+            deleteLater();
+            return;
+        }
+
+        auto imported = m_manager->import_toplevel(m_handle);
+        if (!imported) {
+            qCWarning(waylandForeignParentLog)
+                    << "Failed to import parent window handle";
+            deleteLater();
+            return;
+        }
+
+        new ImportedParent(imported, m_window, surface);
+        deleteLater();
+    }
+
+    QPointer<QWindow> m_window;
+    QPointer<ForeignParentManager> m_manager;
+    QString m_handle;
+    bool m_attemptScheduled = false;
+};
+
+}
+
+bool WaylandForeignParent::setParent(QWindow *window, const QString &handle)
+{
+    if (!window || handle.isEmpty()
+        || QGuiApplication::platformName() != QLatin1String("wayland")) {
+        return false;
+    }
+
+    new ForeignParentBinding(window, handle);
+    return true;
+}

--- a/src/wayland/foreignparent.h
+++ b/src/wayland/foreignparent.h
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include <QString>
+
+class QWindow;
+
+namespace WaylandForeignParent
+{
+
+bool setParent(QWindow *window, const QString &handle);
+
+}

--- a/src/wayland/protocols/common.h
+++ b/src/wayland/protocols/common.h
@@ -9,6 +9,9 @@
 #include <private/qwaylandintegration_p.h>
 #include <QPointer>
 
+#include <cstdint>
+#include <limits>
+
 inline QtWaylandClient::QWaylandIntegration *waylandIntegration()
 {
     return dynamic_cast<QtWaylandClient::QWaylandIntegration *>(QGuiApplicationPrivate::platformIntegration());
@@ -17,4 +20,20 @@ inline QtWaylandClient::QWaylandIntegration *waylandIntegration()
 inline QPointer<QtWaylandClient::QWaylandDisplay> waylandDisplay()
 {
     return waylandIntegration()->display();
+}
+
+inline bool isSafeShmBufferLayout(uint32_t width, uint32_t height, uint32_t stride)
+{
+    if (width == 0 || height == 0) {
+        return false;
+    }
+
+    constexpr uint64_t maxInt = std::numeric_limits<int>::max();
+    if (width > maxInt || height > maxInt) {
+        return false;
+    }
+
+    const uint64_t expectedStride = uint64_t(width) * 4;
+    const uint64_t byteCount = expectedStride * height;
+    return expectedStride == stride && byteCount <= maxInt;
 }

--- a/src/wayland/protocols/screencopy.cpp
+++ b/src/wayland/protocols/screencopy.cpp
@@ -9,6 +9,13 @@ ScreenCopyFrame::ScreenCopyFrame(struct ::zwlr_screencopy_frame_v1 *object)
     , QtWayland::zwlr_screencopy_frame_v1(object)
 { }
 
+ScreenCopyFrame::~ScreenCopyFrame()
+{
+    QObject::disconnect(this, nullptr, nullptr, nullptr);
+    if (isInitialized())
+        destroy();
+}
+
 void ScreenCopyFrame::zwlr_screencopy_frame_v1_buffer(uint32_t format,
                                                       uint32_t width,
                                                       uint32_t height,

--- a/src/wayland/protocols/screencopy.h
+++ b/src/wayland/protocols/screencopy.h
@@ -20,6 +20,7 @@ class ScreenCopyFrame : public QObject, public QtWayland::zwlr_screencopy_frame_
     Q_OBJECT
 public:
     ScreenCopyFrame(struct ::zwlr_screencopy_frame_v1 *object);
+    ~ScreenCopyFrame() override;
 
 Q_SIGNALS:
     void buffer(uint32_t format, uint32_t width, uint32_t height, uint32_t stride);

--- a/src/wayland/protocols/treelandcapture.cpp
+++ b/src/wayland/protocols/treelandcapture.cpp
@@ -6,6 +6,8 @@
 #include "common.h"
 #include "loggings.h"
 
+#include <algorithm>
+
 void destruct_treeland_capture_manager(TreeLandCaptureManager *manager)
 {
     qDeleteAll(manager->captureContexts);
@@ -16,7 +18,15 @@ void destruct_treeland_capture_manager(TreeLandCaptureManager *manager)
 QPointer<TreeLandCaptureContext> TreeLandCaptureManager::getContext()
 {
     auto context = get_context();
+    if (!context) {
+        qCWarning(PORTAL_COMMON) << "Failed to create Treeland capture context";
+        return nullptr;
+    }
     auto captureContext = new TreeLandCaptureContext(context);
+    if (!captureContext->isInitialized()) {
+        delete captureContext;
+        return nullptr;
+    }
     captureContexts.append(captureContext);
     return captureContext;
 }
@@ -29,7 +39,9 @@ TreeLandCaptureContext::TreeLandCaptureContext(struct ::treeland_capture_context
 
 void TreeLandCaptureContext::treeland_capture_context_v1_source_ready(int32_t region_x, int32_t region_y, uint32_t region_width, uint32_t region_height, uint32_t source_type)
 {
-    Q_EMIT sourceReady(QRect(region_x, region_y, region_width, region_height), source_type);
+    m_captureRegion = QRect(region_x, region_y, region_width, region_height);
+    m_sourceType = static_cast<QtWayland::treeland_capture_context_v1::source_type>(source_type);
+    Q_EMIT sourceReady(m_captureRegion, source_type);
 }
 
 void TreeLandCaptureContext::treeland_capture_context_v1_source_failed(uint32_t reason)
@@ -42,6 +54,10 @@ QPointer<TreeLandCaptureFrame> TreeLandCaptureContext::frame()
     if (m_captureFrame)
         return m_captureFrame;
     auto capture_frame = capture();
+    if (!capture_frame) {
+        qCWarning(PORTAL_COMMON) << "Failed to create Treeland capture frame";
+        return nullptr;
+    }
     m_captureFrame = new TreeLandCaptureFrame(capture_frame);
     return m_captureFrame;
 }
@@ -59,16 +75,48 @@ void TreeLandCaptureContext::releaseCaptureFrame() {
 
 void TreeLandCaptureFrame::treeland_capture_frame_v1_buffer(uint32_t format, uint32_t width, uint32_t height, uint32_t stride)
 {
-    if (stride != width * 4) {
-        qCDebug(PORTAL_COMMON)
+    if (m_terminal || m_pendingShmBuffer) {
+        return;
+    }
+    if (!isSafeShmBufferLayout(width, height, stride)) {
+        qCWarning(PORTAL_COMMON)
                 << "Receive a buffer format which is not compatible with QWaylandShmBuffer."
                 << "format:" << format << "width:" << width << "height:" << height
                 << "stride:" << stride;
         return;
     }
-    if (m_pendingShmBuffer)
-        return; // We only need one supported format
-    m_pendingShmBuffer = new QtWaylandClient::QWaylandShmBuffer(waylandDisplay(), QSize(width, height), QtWaylandClient::QWaylandShm::formatFrom(static_cast<::wl_shm_format>(format)));
+
+    const QImage::Format imageFormat = QtWaylandClient::QWaylandShm::formatFrom(
+            static_cast<::wl_shm_format>(format));
+    if (imageFormat == QImage::Format_Invalid) {
+        qCWarning(PORTAL_COMMON) << "Unsupported Treeland capture pixel format" << format;
+        return;
+    }
+
+    m_pendingShmBuffer = new QtWaylandClient::QWaylandShmBuffer(
+            waylandDisplay(), QSize(width, height), imageFormat);
+    if (!m_pendingShmBuffer->buffer() || !m_pendingShmBuffer->image()
+        || m_pendingShmBuffer->image()->isNull()) {
+        qCWarning(PORTAL_COMMON) << "Failed to allocate Treeland capture buffer";
+        delete m_pendingShmBuffer;
+        m_pendingShmBuffer = nullptr;
+        return;
+    }
+}
+
+void TreeLandCaptureFrame::treeland_capture_frame_v1_buffer_done()
+{
+    if (m_terminal || m_copyRequested) {
+        return;
+    }
+    if (!m_pendingShmBuffer || !m_pendingShmBuffer->buffer()) {
+        qCWarning(PORTAL_COMMON) << "Treeland capture offered no usable shared-memory buffer";
+        m_terminal = true;
+        Q_EMIT failed();
+        return;
+    }
+
+    m_copyRequested = true;
     copy(m_pendingShmBuffer->buffer());
 }
 
@@ -79,24 +127,45 @@ void TreeLandCaptureFrame::treeland_capture_frame_v1_flags(uint32_t flags)
 
 void TreeLandCaptureFrame::treeland_capture_frame_v1_ready()
 {
+    if (m_terminal) {
+        return;
+    }
+    if (!m_copyRequested || !m_pendingShmBuffer || !m_pendingShmBuffer->image()
+        || m_pendingShmBuffer->image()->isNull()) {
+        qCWarning(PORTAL_COMMON) << "Treeland capture frame is ready without a valid image";
+        delete m_pendingShmBuffer;
+        m_pendingShmBuffer = nullptr;
+        m_terminal = true;
+        Q_EMIT failed();
+        return;
+    }
     if (m_shmBuffer)
         delete m_shmBuffer;
     m_shmBuffer = m_pendingShmBuffer;
     m_pendingShmBuffer = nullptr;
-    Q_EMIT ready(*m_shmBuffer->image());
+    m_terminal = true;
+    const bool yInverted = m_flags & QtWayland::treeland_capture_frame_v1::flags_y_inverted;
+    Q_EMIT ready(yInverted ? m_shmBuffer->image()->mirrored(false, true)
+                           : *m_shmBuffer->image());
 }
 
 void TreeLandCaptureFrame::treeland_capture_frame_v1_failed()
 {
+    if (m_terminal) {
+        return;
+    }
+    m_terminal = true;
     Q_EMIT failed();
 }
 
 void TreeLandCaptureManager::releaseCaptureContext(QPointer<TreeLandCaptureContext> context)
 {
-    for (const auto &entry : captureContexts) {
-        if (entry == context.data()) {
-            entry->deleteLater();
-            captureContexts.removeOne(entry);
-        }
+    const auto it = std::find(captureContexts.begin(), captureContexts.end(), context.data());
+    if (it == captureContexts.end()) {
+        return;
     }
+
+    auto entry = *it;
+    captureContexts.erase(it);
+    entry->deleteLater();
 }

--- a/src/wayland/protocols/treelandcapture.h
+++ b/src/wayland/protocols/treelandcapture.h
@@ -19,13 +19,16 @@ public:
         , m_shmBuffer(nullptr)
         , m_pendingShmBuffer(nullptr)
         , m_flags(0)
+        , m_copyRequested(false)
+        , m_terminal(false)
     { }
 
     ~TreeLandCaptureFrame() override
     {
+        if (isInitialized())
+            destroy();
         delete m_shmBuffer;
         delete m_pendingShmBuffer;
-        destroy();
     }
 
     inline uint flags() const { return m_flags; }
@@ -36,6 +39,7 @@ Q_SIGNALS:
 
 protected:
     void treeland_capture_frame_v1_buffer(uint32_t format, uint32_t width, uint32_t height, uint32_t stride) override;
+    void treeland_capture_frame_v1_buffer_done() override;
     void treeland_capture_frame_v1_flags(uint32_t flags) override;
     void treeland_capture_frame_v1_ready() override;
     void treeland_capture_frame_v1_failed() override;
@@ -44,6 +48,8 @@ private:
     QtWaylandClient::QWaylandShmBuffer *m_shmBuffer;
     QtWaylandClient::QWaylandShmBuffer *m_pendingShmBuffer;
     uint m_flags;
+    bool m_copyRequested;
+    bool m_terminal;
 };
 
 class TreeLandCaptureContext : public QObject, public QtWayland::treeland_capture_context_v1
@@ -54,7 +60,8 @@ public:
     ~TreeLandCaptureContext() override
     {
         releaseCaptureFrame();
-        destroy();
+        if (isInitialized())
+            destroy();
     }
 
     inline QRect captureRegion() const { return m_captureRegion; }
@@ -75,7 +82,8 @@ protected:
 private:
     QRect m_captureRegion;
     TreeLandCaptureFrame *m_captureFrame;
-    QtWayland::treeland_capture_context_v1::source_type m_sourceType;
+    QtWayland::treeland_capture_context_v1::source_type m_sourceType =
+            static_cast<QtWayland::treeland_capture_context_v1::source_type>(0);
 };
 
 class TreeLandCaptureManager;
@@ -93,7 +101,8 @@ public:
 
     ~TreeLandCaptureManager() override
     {
-        destroy();
+        if (isInitialized())
+            destroy();
     }
 
     QPointer<TreeLandCaptureContext> getContext();

--- a/src/wayland/request2.cpp
+++ b/src/wayland/request2.cpp
@@ -19,26 +19,35 @@ Request2::Request2(const QDBusObjectPath &handle, QObject *parent, const QString
     : QDBusVirtualObject(parent)
     , m_data(data)
     , m_portalName(portalName)
+    , m_path(handle.path())
 {
     auto sessionBus = QDBusConnection::sessionBus();
-    if (sessionBus.registerVirtualObject(handle.path(), this, QDBusConnection::VirtualObjectRegisterOption::SubPath)) {
-        connect(this, &Request2::closeRequested, this, [this, handle]() {
-            QDBusConnection::sessionBus().unregisterObject(handle.path());
-            deleteLater();
-        });
-    } else {
+    m_registered = sessionBus.registerVirtualObject(
+            m_path, this, QDBusConnection::VirtualObjectRegisterOption::SingleNode);
+    if (!m_registered) {
         qCDebug(PORTAL_COMMON) << sessionBus.lastError().message();
-        qCDebug(PORTAL_COMMON) << "Failed to register request object for" << handle.path();
-        deleteLater();
+        qCDebug(PORTAL_COMMON) << "Failed to register request object for" << m_path;
     }
+}
+
+Request2::~Request2()
+{
+    unregister();
+}
+
+void Request2::unregister()
+{
+    if (!m_registered) {
+        return;
+    }
+    QDBusConnection::sessionBus().unregisterObject(m_path);
+    m_registered = false;
 }
 
 bool Request2::handleMessage(const QDBusMessage &message, const QDBusConnection &connection)
 {
-    Q_UNUSED(connection);
-
-    /* Check to make sure we're getting properties on our interface */
-    if (message.type() != QDBusMessage::MessageType::MethodCallMessage) {
+    if (!m_registered || message.type() != QDBusMessage::MessageType::MethodCallMessage
+        || message.path() != m_path) {
         return false;
     }
 
@@ -50,18 +59,21 @@ bool Request2::handleMessage(const QDBusMessage &message, const QDBusConnection 
         if (message.member() == QLatin1String("Close")) {
             Q_EMIT closeRequested();
             QDBusMessage reply = message.createReply();
-            return connection.send(reply);
+            const bool sent = connection.send(reply);
+            unregister();
+            deleteLater();
+            return sent;
         }
     }
 
-    return true;
+    return false;
 }
 
 QString Request2::introspect(const QString &path) const
 {
     QString nodes;
 
-    if (path.startsWith(QLatin1String("/org/freedesktop/portal/desktop/request/"))) {
+    if (path == m_path) {
         nodes = QStringLiteral(
             "<interface name=\"org.freedesktop.impl.portal.Request\">"
             "    <method name=\"Close\">"

--- a/src/wayland/request2.h
+++ b/src/wayland/request2.h
@@ -21,6 +21,10 @@ class Request2 : public QDBusVirtualObject
     Q_OBJECT
 public:
     explicit Request2(const QDBusObjectPath &handle, QObject *parent = nullptr, const QString &portalName = QString(), const QVariant &data = QVariant());
+    ~Request2() override;
+
+    bool isRegistered() const { return m_registered; }
+    void unregister();
 
     bool handleMessage(const QDBusMessage &message, const QDBusConnection &connection) override;
     QString introspect(const QString &path) const override;
@@ -47,4 +51,6 @@ Q_SIGNALS:
 private:
     const QVariant m_data;
     const QString m_portalName;
+    const QString m_path;
+    bool m_registered = false;
 };

--- a/src/wayland/screenshotimage.cpp
+++ b/src/wayland/screenshotimage.cpp
@@ -1,0 +1,204 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "screenshotimage.h"
+
+#include <QPainter>
+#include <QTransform>
+
+#include <algorithm>
+#include <cmath>
+
+namespace ScreenshotImage
+{
+namespace
+{
+
+class AxisMapper
+{
+public:
+    AxisMapper(const QList<Output> &outputs, bool horizontal)
+        : m_horizontal(horizontal)
+    {
+        for (const auto &output : outputs) {
+            const int start = axisStart(output);
+            const int end = axisEnd(output);
+            m_boundaries.append(start);
+            m_boundaries.append(end);
+        }
+
+        std::sort(m_boundaries.begin(), m_boundaries.end());
+        m_boundaries.erase(std::unique(m_boundaries.begin(), m_boundaries.end()),
+                           m_boundaries.end());
+        if (m_boundaries.isEmpty()) {
+            return;
+        }
+
+        m_physicalBoundaries.reserve(m_boundaries.size());
+        m_physicalBoundaries.append(0.0);
+        qreal physical = 0.0;
+        for (qsizetype i = 0; i + 1 < m_boundaries.size(); ++i) {
+            const int start = m_boundaries.at(i);
+            const int end = m_boundaries.at(i + 1);
+            qreal scale = 1.0;
+            bool covered = false;
+
+            for (const auto &output : outputs) {
+                if (axisStart(output) <= start && axisEnd(output) >= end) {
+                    const int logicalSize = axisSize(output.logicalGeometry);
+                    const int pixelSize = axisSize(output.image.size());
+                    if (logicalSize > 0 && pixelSize > 0) {
+                        const qreal outputScale = static_cast<qreal>(pixelSize) / logicalSize;
+                        scale = covered ? std::max(scale, outputScale) : outputScale;
+                        covered = true;
+                    }
+                }
+            }
+
+            physical += static_cast<qreal>(end - start) * scale;
+            m_physicalBoundaries.append(physical);
+        }
+    }
+
+    int map(int logical) const
+    {
+        if (m_boundaries.isEmpty()) {
+            return 0;
+        }
+
+        const auto it = std::lower_bound(m_boundaries.cbegin(), m_boundaries.cend(), logical);
+        if (it == m_boundaries.cend()) {
+            return qRound(m_physicalBoundaries.constLast());
+        }
+
+        const qsizetype index = std::distance(m_boundaries.cbegin(), it);
+        if (*it == logical || index == 0) {
+            return qRound(m_physicalBoundaries.at(index));
+        }
+
+        const int segmentStart = m_boundaries.at(index - 1);
+        const int segmentEnd = m_boundaries.at(index);
+        const qreal physicalStart = m_physicalBoundaries.at(index - 1);
+        const qreal physicalEnd = m_physicalBoundaries.at(index);
+        const qreal ratio = static_cast<qreal>(logical - segmentStart)
+                / static_cast<qreal>(segmentEnd - segmentStart);
+        return qRound(physicalStart + ratio * (physicalEnd - physicalStart));
+    }
+
+private:
+    int axisStart(const Output &output) const
+    {
+        return m_horizontal ? output.logicalGeometry.x() : output.logicalGeometry.y();
+    }
+
+    int axisEnd(const Output &output) const
+    {
+        return axisStart(output) + axisSize(output.logicalGeometry);
+    }
+
+    int axisSize(const QRect &rect) const
+    {
+        return m_horizontal ? rect.width() : rect.height();
+    }
+
+    int axisSize(const QSize &size) const
+    {
+        return m_horizontal ? size.width() : size.height();
+    }
+
+    bool m_horizontal;
+    QList<int> m_boundaries;
+    QList<qreal> m_physicalBoundaries;
+};
+
+void setError(QString *errorMessage, const QString &message)
+{
+    if (errorMessage) {
+        *errorMessage = message;
+    }
+}
+
+}
+
+QImage normalizeOutput(const QImage &image, int transform, bool yInverted)
+{
+    if (image.isNull() || transform < 0 || transform > 7) {
+        return {};
+    }
+
+    QImage result = yInverted ? image.mirrored(false, true) : image;
+    QTransform rotation;
+    switch (transform & 3) {
+    case 1:
+        rotation.rotate(90);
+        break;
+    case 2:
+        rotation.rotate(180);
+        break;
+    case 3:
+        rotation.rotate(270);
+        break;
+    default:
+        break;
+    }
+
+    if (!rotation.isIdentity()) {
+        result = result.transformed(rotation, Qt::FastTransformation);
+    }
+    if (transform >= 4) {
+        result = result.mirrored(true, false);
+    }
+    return result;
+}
+
+QImage composeOutputs(const QList<Output> &outputs, QString *errorMessage)
+{
+    if (outputs.isEmpty()) {
+        setError(errorMessage, QStringLiteral("No outputs to compose"));
+        return {};
+    }
+
+    for (const auto &output : outputs) {
+        if (output.logicalGeometry.isEmpty() || output.image.isNull()) {
+            setError(errorMessage,
+                     QStringLiteral("Invalid output geometry or image for %1").arg(output.name));
+            return {};
+        }
+    }
+
+    const AxisMapper xMapper(outputs, true);
+    const AxisMapper yMapper(outputs, false);
+    QList<QRect> targetRects;
+    targetRects.reserve(outputs.size());
+    QRect physicalRegion;
+    for (const auto &output : outputs) {
+        const QRect targetRect(QPoint(xMapper.map(output.logicalGeometry.x()),
+                                      yMapper.map(output.logicalGeometry.y())),
+                               output.image.size());
+        targetRects.append(targetRect);
+        physicalRegion = physicalRegion.united(targetRect);
+    }
+
+    if (physicalRegion.isEmpty()) {
+        setError(errorMessage, QStringLiteral("Composed output region is empty"));
+        return {};
+    }
+
+    QImage result(physicalRegion.size(), QImage::Format_ARGB32_Premultiplied);
+    if (result.isNull()) {
+        setError(errorMessage, QStringLiteral("Failed to allocate screenshot image"));
+        return {};
+    }
+    result.fill(Qt::transparent);
+
+    QPainter painter(&result);
+    for (qsizetype i = 0; i < outputs.size(); ++i) {
+        painter.drawImage(targetRects.at(i).topLeft() - physicalRegion.topLeft(),
+                          outputs.at(i).image);
+    }
+    painter.end();
+    return result;
+}
+
+}

--- a/src/wayland/screenshotimage.h
+++ b/src/wayland/screenshotimage.h
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include <QImage>
+#include <QList>
+#include <QRect>
+#include <QString>
+
+namespace ScreenshotImage
+{
+
+struct Output
+{
+    QRect logicalGeometry;
+    QImage image;
+    QString name;
+};
+
+QImage normalizeOutput(const QImage &image, int transform, bool yInverted);
+QImage composeOutputs(const QList<Output> &outputs, QString *errorMessage = nullptr);
+
+}

--- a/src/wayland/screenshotportal.cpp
+++ b/src/wayland/screenshotportal.cpp
@@ -1,206 +1,511 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
 #include "screenshotportal.h"
-#include "protocols/common.h"
-#include "protocols/treelandcapture.h"
-#include "loggings.h"
+
 #include "dbushelpers.h"
+#include "loggings.h"
+#include "portalwaylandcontext.h"
+#include "protocols/common.h"
+#include "protocols/screencopy.h"
+#include "protocols/treelandcapture.h"
+#include "request2.h"
+#include "screenshotimage.h"
 
-#include <QApplication>
-#include <QScreen>
-#include <QPainter>
+#include <QDateTime>
+#include <QDBusConnection>
 #include <QDir>
-#include <QRegion>
+#include <QPointer>
 #include <QStandardPaths>
+#include <QTemporaryFile>
+#include <QTimer>
+#include <QUrl>
 
+#include <private/qwaylanddisplay_p.h>
 #include <private/qwaylandscreen_p.h>
 
-Q_LOGGING_CATEGORY(portalWayland, "dde.portal.wayland");
-struct ScreenCaptureInfo {
-    QtWaylandClient::QWaylandScreen *screen {nullptr};
-    QPointer<ScreenCopyFrame> capturedFrame {nullptr};
-    QtWaylandClient::QWaylandShmBuffer *shmBuffer {nullptr};
-    QtWayland::zwlr_screencopy_frame_v1::flags flags;
-};
+#include <algorithm>
+#include <memory>
+#include <utility>
 
-static void destroyScreenCaptureInfo(std::list<std::shared_ptr<ScreenCaptureInfo>> captureList)
+namespace
 {
-    for (const auto &info : std::as_const(captureList)) {
-        if (info->shmBuffer) {
-            delete info->shmBuffer;
+
+constexpr int CaptureTimeoutMs = 10000;
+
+class OutputTransformObserver final : public QtWayland::wl_output
+{
+public:
+    OutputTransformObserver(QtWaylandClient::QWaylandDisplay *display, uint32_t outputId)
+    {
+        if (!display) {
+            return;
         }
 
-        if (info->capturedFrame) {
-            delete info->capturedFrame;
+        const auto globals = display->globals();
+        const auto global = std::find_if(globals.cbegin(), globals.cend(), [outputId](const auto &entry) {
+            return entry.id == outputId && entry.interface == QStringLiteral("wl_output");
+        });
+        if (global != globals.cend()) {
+            init(display->wl_registry(), global->id, std::min(global->version, uint32_t(4)));
         }
     }
+
+    ~OutputTransformObserver() override
+    {
+        if (!isInitialized()) {
+            return;
+        }
+        if (version() >= 3) {
+            release();
+        } else {
+            ::wl_output_destroy(object());
+        }
+    }
+
+    int transform() const { return m_transform; }
+    bool receivedTransform() const { return m_receivedTransform; }
+
+protected:
+    void output_geometry(int32_t,
+                         int32_t,
+                         int32_t,
+                         int32_t,
+                         int32_t,
+                         const QString &,
+                         const QString &,
+                         int32_t transform) override
+    {
+        if (transform >= transform_normal && transform <= transform_flipped_270) {
+            m_transform = transform;
+            m_receivedTransform = true;
+        }
+    }
+
+private:
+    int m_transform = transform_normal;
+    bool m_receivedTransform = false;
+};
+
+struct ScreenCapture
+{
+    QString name;
+    QRect logicalGeometry;
+    std::unique_ptr<OutputTransformObserver> transformObserver;
+    std::unique_ptr<QtWaylandClient::QWaylandShmBuffer> buffer;
+    std::unique_ptr<ScreenCopyFrame> frame;
+    uint32_t flags = 0;
+    bool waitForBufferDone = false;
+    bool copyRequested = false;
+    bool finished = false;
+};
+
+QString saveScreenshot(const QImage &image)
+{
+    if (image.isNull()) {
+        return {};
+    }
+
+    const QString picturesPath = QStandardPaths::writableLocation(QStandardPaths::PicturesLocation);
+    if (picturesPath.isEmpty()) {
+        qCWarning(SCREESHOT) << "No writable Pictures location is available";
+        return {};
+    }
+
+    QDir picturesDir(picturesPath);
+    if (!picturesDir.exists() && !picturesDir.mkpath(QStringLiteral("."))) {
+        qCWarning(SCREESHOT) << "Failed to create Pictures directory" << picturesPath;
+        return {};
+    }
+
+    const QString timestamp = QDateTime::currentDateTime().toString(QStringLiteral("yyyyMMdd_HHmmss_zzz"));
+    QTemporaryFile file(picturesDir.filePath(
+            QStringLiteral("Screenshot_%1_XXXXXX.png").arg(timestamp)));
+    if (!file.open()) {
+        qCWarning(SCREESHOT) << "Failed to create screenshot file in" << picturesPath
+                             << file.errorString();
+        return {};
+    }
+    if (!image.save(&file, "PNG") || !file.flush()) {
+        qCWarning(SCREESHOT) << "Failed to save screenshot" << file.errorString();
+        return {};
+    }
+
+    file.setAutoRemove(false);
+    return file.fileName();
+}
+
+PortalResponse::Response responseFromSourceFailure(uint32_t reason)
+{
+    using CaptureContext = QtWayland::treeland_capture_context_v1;
+    return reason == CaptureContext::source_failure_user_cancel
+            ? PortalResponse::Cancelled
+            : PortalResponse::OtherError;
+}
+
+class ScreenshotOperation final : public QObject
+{
+public:
+    ScreenshotOperation(PortalWaylandContext *context,
+                        const QDBusObjectPath &handle,
+                        const QDBusMessage &message,
+                        bool interactive,
+                        QObject *parent)
+        : QObject(parent)
+        , m_context(context)
+        , m_message(message)
+        , m_interactive(interactive)
+        , m_request(new Request2(handle, this, QStringLiteral("Screenshot")))
+    {
+        m_captureTimeout.setSingleShot(true);
+        connect(&m_captureTimeout, &QTimer::timeout, this, [this] {
+            qCWarning(SCREESHOT) << "Screenshot capture timed out";
+            finish(PortalResponse::OtherError);
+        });
+        connect(m_request, &Request2::closeRequested, this, [this] {
+            finish(PortalResponse::Cancelled);
+        });
+    }
+
+    ~ScreenshotOperation() override
+    {
+        releaseInteractiveContext();
+    }
+
+    void start()
+    {
+        if (!m_request->isRegistered()) {
+            finish(PortalResponse::OtherError);
+            return;
+        }
+
+        if (m_interactive) {
+            startInteractiveCapture();
+        } else {
+            startFullscreenCapture();
+        }
+    }
+
+private:
+    void startFullscreenCapture()
+    {
+        auto manager = m_context ? m_context->screenCopyManager() : nullptr;
+        if (!manager || !manager->isActive()) {
+            qCWarning(SCREESHOT) << "Screen copy manager is not active";
+            finish(PortalResponse::OtherError);
+            return;
+        }
+
+        auto display = waylandDisplay();
+        const auto screens = display ? display->screens() : QList<QtWaylandClient::QWaylandScreen *>();
+        if (screens.isEmpty()) {
+            qCWarning(SCREESHOT) << "No Wayland outputs are available";
+            finish(PortalResponse::OtherError);
+            return;
+        }
+
+        m_pendingOutputs = screens.size();
+        m_outputs.reserve(screens.size());
+        for (auto screen : screens) {
+            auto capture = std::make_shared<ScreenCapture>();
+            capture->name = screen->name();
+            capture->logicalGeometry = screen->geometry();
+            capture->waitForBufferDone = manager->version() >= 3;
+            capture->transformObserver = std::make_unique<OutputTransformObserver>(
+                    display, screen->outputId());
+
+            auto frame = manager->captureOutput(false, screen->output());
+            if (!frame || !frame->isInitialized()) {
+                qCWarning(SCREESHOT) << "Failed to create screencopy frame for" << capture->name;
+                finish(PortalResponse::OtherError);
+                return;
+            }
+            capture->frame.reset(frame.data());
+            m_outputs.append(capture);
+
+            connect(capture->frame.get(), &ScreenCopyFrame::buffer, this,
+                    [this, capture, display](uint32_t format,
+                                             uint32_t width,
+                                             uint32_t height,
+                                             uint32_t stride) {
+                if (m_finished || capture->finished || capture->buffer) {
+                    return;
+                }
+                if (!isSafeShmBufferLayout(width, height, stride)) {
+                    qCWarning(SCREESHOT) << "Unsupported screencopy buffer for" << capture->name
+                                         << format << width << height << stride;
+                    if (!capture->waitForBufferDone) {
+                        finishOutput(capture, false);
+                    }
+                    return;
+                }
+
+                const QImage::Format imageFormat = QtWaylandClient::QWaylandShm::formatFrom(
+                        static_cast<::wl_shm_format>(format));
+                if (imageFormat == QImage::Format_Invalid) {
+                    qCWarning(SCREESHOT) << "Unsupported screencopy pixel format" << format;
+                    if (!capture->waitForBufferDone) {
+                        finishOutput(capture, false);
+                    }
+                    return;
+                }
+
+                capture->buffer = std::make_unique<QtWaylandClient::QWaylandShmBuffer>(
+                        display, QSize(width, height), imageFormat);
+                if (!capture->buffer->buffer() || !capture->buffer->image()
+                    || capture->buffer->image()->isNull()) {
+                    qCWarning(SCREESHOT) << "Failed to allocate screencopy buffer for"
+                                         << capture->name;
+                    capture->buffer.reset();
+                    if (!capture->waitForBufferDone) {
+                        finishOutput(capture, false);
+                    }
+                    return;
+                }
+                if (!capture->waitForBufferDone) {
+                    capture->copyRequested = true;
+                    capture->frame->copy(capture->buffer->buffer());
+                }
+            });
+            connect(capture->frame.get(), &ScreenCopyFrame::bufferDone, this,
+                    [this, capture] {
+                if (m_finished || capture->finished || capture->copyRequested) {
+                    return;
+                }
+                if (!capture->buffer || !capture->buffer->buffer()) {
+                    qCWarning(SCREESHOT) << "No usable screencopy shared-memory buffer for"
+                                         << capture->name;
+                    finishOutput(capture, false);
+                    return;
+                }
+                capture->copyRequested = true;
+                capture->frame->copy(capture->buffer->buffer());
+            });
+            connect(capture->frame.get(), &ScreenCopyFrame::frameFlags, this,
+                    [capture](uint32_t flags) {
+                capture->flags = flags;
+            });
+            connect(capture->frame.get(), &ScreenCopyFrame::ready, this,
+                    [this, capture](uint32_t, uint32_t, uint32_t) {
+                const QImage *image = capture->buffer ? capture->buffer->image() : nullptr;
+                finishOutput(capture, image && !image->isNull());
+            });
+            connect(capture->frame.get(), &ScreenCopyFrame::failed, this,
+                    [this, capture] {
+                finishOutput(capture, false);
+            });
+        }
+
+        m_captureTimeout.start(CaptureTimeoutMs);
+    }
+
+    void finishOutput(const std::shared_ptr<ScreenCapture> &capture, bool succeeded)
+    {
+        if (m_finished || capture->finished) {
+            return;
+        }
+        capture->finished = true;
+        if (!succeeded) {
+            qCWarning(SCREESHOT) << "Screencopy failed for" << capture->name;
+            finish(PortalResponse::OtherError);
+            return;
+        }
+
+        if (--m_pendingOutputs != 0) {
+            return;
+        }
+        m_captureTimeout.stop();
+
+        QList<ScreenshotImage::Output> outputs;
+        outputs.reserve(m_outputs.size());
+        for (const auto &entry : std::as_const(m_outputs)) {
+            const bool yInverted = entry->flags
+                    & QtWayland::zwlr_screencopy_frame_v1::flags_y_invert;
+            const int transform = entry->transformObserver
+                    ? entry->transformObserver->transform()
+                    : int(QtWayland::wl_output::transform_normal);
+            if (entry->transformObserver && !entry->transformObserver->receivedTransform()) {
+                qCWarning(SCREESHOT) << "No wl_output transform received for" << entry->name
+                                     << "; assuming normal";
+            }
+            const QImage normalized = ScreenshotImage::normalizeOutput(
+                    *entry->buffer->image(), transform, yInverted);
+            if (normalized.isNull()) {
+                finish(PortalResponse::OtherError);
+                return;
+            }
+            outputs.append({entry->logicalGeometry, normalized, entry->name});
+        }
+
+        QString errorMessage;
+        const QImage image = ScreenshotImage::composeOutputs(outputs, &errorMessage);
+        if (image.isNull()) {
+            qCWarning(SCREESHOT) << "Failed to compose screenshot:" << errorMessage;
+            finish(PortalResponse::OtherError);
+            return;
+        }
+        finish(PortalResponse::Success, image);
+    }
+
+    void startInteractiveCapture()
+    {
+        m_captureManager = m_context ? m_context->treelandCaptureManager() : nullptr;
+        if (!m_captureManager || !m_captureManager->isActive()) {
+            qCWarning(SCREESHOT) << "Treeland capture manager is not active";
+            finish(PortalResponse::OtherError);
+            return;
+        }
+
+        m_captureContext = m_captureManager->getContext();
+        if (!m_captureContext || !m_captureContext->isInitialized()) {
+            finish(PortalResponse::OtherError);
+            return;
+        }
+
+        connect(m_captureManager, &TreeLandCaptureManager::activeChanged, this, [this] {
+            if (!m_captureManager || !m_captureManager->isActive()) {
+                finish(PortalResponse::OtherError);
+            }
+        });
+        connect(m_captureContext, &TreeLandCaptureContext::sourceReady, this,
+                [this](const QRect &, uint32_t) {
+            startInteractiveFrame();
+        });
+        connect(m_captureContext, &TreeLandCaptureContext::sourceFailed, this,
+                [this](uint32_t reason) {
+            qCWarning(SCREESHOT) << "Treeland source selection failed with reason" << reason;
+            finish(responseFromSourceFailure(reason));
+        });
+
+        m_captureContext->selectSource(
+                QtWayland::treeland_capture_context_v1::source_type_output
+                        | QtWayland::treeland_capture_context_v1::source_type_window
+                        | QtWayland::treeland_capture_context_v1::source_type_region,
+                true,
+                false,
+                nullptr);
+    }
+
+    void startInteractiveFrame()
+    {
+        if (m_finished || m_interactiveFrameStarted || !m_captureContext) {
+            return;
+        }
+        m_interactiveFrameStarted = true;
+        auto frame = m_captureContext->frame();
+        if (!frame || !frame->isInitialized()) {
+            finish(PortalResponse::OtherError);
+            return;
+        }
+
+        connect(frame, &TreeLandCaptureFrame::ready, this, [this](const QImage &image) {
+            if (image.isNull()) {
+                finish(PortalResponse::OtherError);
+                return;
+            }
+            finish(PortalResponse::Success, image);
+        });
+        connect(frame, &TreeLandCaptureFrame::failed, this, [this] {
+            finish(PortalResponse::OtherError);
+        });
+        m_captureTimeout.start(CaptureTimeoutMs);
+    }
+
+    void releaseInteractiveContext()
+    {
+        if (m_captureManager && m_captureContext) {
+            m_captureManager->releaseCaptureContext(m_captureContext);
+        }
+        m_captureContext.clear();
+        m_captureManager.clear();
+    }
+
+    void finish(PortalResponse::Response response, const QImage &image = {})
+    {
+        if (m_finished) {
+            return;
+        }
+        m_finished = true;
+        m_captureTimeout.stop();
+        releaseInteractiveContext();
+
+        QVariantMap results;
+        if (response == PortalResponse::Success) {
+            const QString filePath = saveScreenshot(image);
+            if (filePath.isEmpty()) {
+                response = PortalResponse::OtherError;
+            } else {
+                results.insert(QStringLiteral("uri"),
+                               QUrl::fromLocalFile(filePath).toString(QUrl::FullyEncoded));
+            }
+        }
+
+        if (m_request) {
+            m_request->unregister();
+        }
+        const QDBusMessage reply = m_message.createReply(
+                QVariantList{QVariant::fromValue(uint(response)), results});
+        if (!QDBusConnection::sessionBus().send(reply)) {
+            qCWarning(SCREESHOT) << "Failed to send screenshot response";
+        }
+        if (m_request) {
+            m_request->deleteLater();
+        }
+        deleteLater();
+    }
+
+    PortalWaylandContext *m_context = nullptr;
+    QDBusMessage m_message;
+    bool m_interactive = false;
+    bool m_interactiveFrameStarted = false;
+    bool m_finished = false;
+    QPointer<Request2> m_request;
+    QTimer m_captureTimeout;
+    QList<std::shared_ptr<ScreenCapture>> m_outputs;
+    qsizetype m_pendingOutputs = 0;
+    QPointer<TreeLandCaptureManager> m_captureManager;
+    QPointer<TreeLandCaptureContext> m_captureContext;
+};
+
 }
 
 ScreenshotPortalWayland::ScreenshotPortalWayland(PortalWaylandContext *context)
     : AbstractWaylandPortal(context)
 {
-
 }
 
 uint ScreenshotPortalWayland::PickColor(const QDBusObjectPath &handle,
-                                 const QString &app_id,
-                                 const QString &parent_window, // might just ignore this argument now
-                                 const QVariantMap &options,
-                                 QVariantMap &results)
+                                        const QString &app_id,
+                                        const QString &parent_window,
+                                        const QVariantMap &options,
+                                        QVariantMap &results)
 {
-    // TODO Implement PickColor
-    qCDebug(SCREESHOT) << "PickColor called with parameters:";
-    qCDebug(SCREESHOT) << "    handle: " << handle.path();
-    qCDebug(SCREESHOT) << "    app_id: " << app_id;
-    qCDebug(SCREESHOT) << "    parent_window: " << parent_window;
-    qCDebug(SCREESHOT) << "    options: " << options;
-
+    Q_UNUSED(handle)
+    Q_UNUSED(app_id)
+    Q_UNUSED(parent_window)
+    Q_UNUSED(options)
+    Q_UNUSED(results)
     return PortalResponse::Cancelled;
 }
 
-QString ScreenshotPortalWayland::fullScreenShot()
+void ScreenshotPortalWayland::Screenshot(const QDBusObjectPath &handle,
+                                         const QString &app_id,
+                                         const QString &parent_window,
+                                         const QVariantMap &options,
+                                         const QDBusMessage &message,
+                                         uint &replyResponse,
+                                         QVariantMap &replyResults)
 {
-    std::list<std::shared_ptr<ScreenCaptureInfo>> captureList;
-    int pendingCapture = 0;
-    auto screenCopyManager = context()->screenCopyManager();
-    QEventLoop eventLoop;
-    QRegion outputRegion;
-    QImage::Format formatLast;
-    // Capture each output
-    for (auto screen : waylandDisplay()->screens()) {
-        auto info = std::make_shared<ScreenCaptureInfo>();
-        outputRegion += screen->geometry();
-        auto output = screen->output();
-        info->capturedFrame = screenCopyManager->captureOutput(false, output);
-        info->screen = screen;
-        ++pendingCapture;
-        captureList.push_back(info);
-        connect(info->capturedFrame, &ScreenCopyFrame::buffer, this,
-                [info](uint32_t format, uint32_t width, uint32_t height, uint32_t stride){
-                    // Create a new wl_buffer for reception
-                    // For some reason, Qt regards stride == width * 4, and it creates buffer likewise, we must check this
-                    if (stride != width * 4) {
-                        qCDebug(SCREESHOT)
-                        << "Receive a buffer format which is not compatible with QWaylandShmBuffer."
-                        << "format:" << format << "width:" << width << "height:" << height
-                        << "stride:" << stride;
-                        return;
-                    }
-                    if (info->shmBuffer)
-                        return; // We only need one supported format
+    Q_UNUSED(app_id)
+    Q_UNUSED(parent_window)
+    Q_UNUSED(replyResponse)
+    Q_UNUSED(replyResults)
 
-                    info->shmBuffer = new QtWaylandClient::QWaylandShmBuffer(
-                            waylandDisplay(),
-                            QSize(width, height),
-                            QtWaylandClient::QWaylandShm::formatFrom(static_cast<::wl_shm_format>(format)));
-                    info->capturedFrame->copy(info->shmBuffer->buffer());
-                });
-        connect(info->capturedFrame, &ScreenCopyFrame::frameFlags, this,
-                [info](uint32_t flags){
-                    info->flags = static_cast<QtWayland::zwlr_screencopy_frame_v1::flags>(flags);
-                });
-        connect(info->capturedFrame, &ScreenCopyFrame::ready, this,
-                [info, &pendingCapture, &eventLoop, &formatLast](uint32_t tv_sec_hi, uint32_t tv_sec_lo, uint32_t tv_nsec) {
-                    Q_UNUSED(tv_sec_hi);
-                    Q_UNUSED(tv_sec_lo);
-                    Q_UNUSED(tv_nsec);
-                    formatLast = info->shmBuffer->image()->format();
-                    if (--pendingCapture == 0) {
-                        eventLoop.quit();
-                    }
-                });
-        connect(info->capturedFrame, &ScreenCopyFrame::failed, this, [&pendingCapture, &eventLoop]{
-            if (--pendingCapture == 0) {
-                eventLoop.quit();
-            }
-        });
-    }
-    eventLoop.exec();
-    // Cat them according to layout
-    QImage image(outputRegion.boundingRect().size(), formatLast);
-    QPainter p(&image);
-    p.setRenderHint(QPainter::Antialiasing);
-    for (const auto &info : std::as_const(captureList)) {
-        if (info->shmBuffer) {
-            QRect targetRect = info->screen->geometry();
-            // Convert to screen image local coordinates
-            auto sourceRect = targetRect;
-            sourceRect.moveTo(sourceRect.topLeft() - info->screen->geometry().topLeft());
-            p.drawImage(targetRect, *info->shmBuffer->image(), sourceRect);
-        } else {
-            qCWarning(portalWayland) << "image is null!!!";
-        }
-    }
-    static const char *SaveFormat = "PNG";
-    auto saveBasePath = QStandardPaths::writableLocation(QStandardPaths::PicturesLocation);
-    QDir saveBaseDir(saveBasePath);
-    if (!saveBaseDir.exists()) return "";
-    QString picName = "portal screenshot - " + QDateTime::currentDateTime().toString() + ".png";
-    if (image.save(saveBaseDir.absoluteFilePath(picName), SaveFormat)) {
-        destroyScreenCaptureInfo(captureList);
-        return saveBaseDir.absoluteFilePath(picName);
-    } else {
-        destroyScreenCaptureInfo(captureList);
-        return "";
-    }
-}
-
-QString ScreenshotPortalWayland::captureInteractively()
-{
-    auto captureManager = context()->treelandCaptureManager();
-    auto captureContext = captureManager->getContext();
-    if (!captureContext) {
-        return "";
-    }
-    captureContext->selectSource(QtWayland::treeland_capture_context_v1::source_type_output
-                                         | QtWayland::treeland_capture_context_v1::source_type_window
-                                         | QtWayland::treeland_capture_context_v1::source_type_region
-                                 ,true
-                                 , false
-                                 ,nullptr);
-    QEventLoop loop;
-    connect(captureContext, &TreeLandCaptureContext::sourceReady, &loop, &QEventLoop::quit);
-    loop.exec();
-    auto frame = captureContext->frame();
-    QImage result;
-    connect(frame, &TreeLandCaptureFrame::ready, this, [this, &result, &loop](QImage image) {
-        result = image;
-        loop.quit();
+    message.setDelayedReply(true);
+    const bool interactive = options.value(QStringLiteral("interactive"), false).toBool();
+    auto operation = new ScreenshotOperation(context(), handle, message, interactive, this);
+    QTimer::singleShot(0, operation, [operation] {
+        operation->start();
     });
-    connect(frame, &TreeLandCaptureFrame::failed, &loop, &QEventLoop::quit);
-    loop.exec();
-    if (result.isNull()) return "";
-    auto saveBasePath = QStandardPaths::writableLocation(QStandardPaths::PicturesLocation);
-    QDir saveBaseDir(saveBasePath);
-    if (!saveBaseDir.exists()) return "";
-    QString picName = "portal screenshot - " + QDateTime::currentDateTime().toString() + ".png";
-    if (result.save(saveBaseDir.absoluteFilePath(picName), "PNG")) {
-        return saveBaseDir.absoluteFilePath(picName);
-    } else {
-        return "";
-    }
-}
-
-uint ScreenshotPortalWayland::Screenshot(const QDBusObjectPath &handle,
-                                  const QString &app_id,
-                                  const QString &parent_window,
-                                  const QVariantMap &options,
-                                  QVariantMap &results)
-{
-    if (options["modal"].toBool()) {
-        // TODO if modal, we should block parent_window
-    }
-    QString filePath;
-    if (options["interactive"].toBool()) {
-        filePath = captureInteractively();
-    } else {
-        filePath = fullScreenShot();
-    }
-    if (filePath.isEmpty()) {
-        return 1;
-    }
-    results.insert(QStringLiteral("uri"), QUrl::fromLocalFile(filePath).toString(QUrl::FullyEncoded));
-    return 0;
 }

--- a/src/wayland/screenshotportal.h
+++ b/src/wayland/screenshotportal.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -6,6 +6,7 @@
 
 #include "abstractwaylandportal.h"
 
+#include <QDBusMessage>
 #include <QDBusObjectPath>
 #include <QObject>
 
@@ -13,12 +14,12 @@ class ScreenshotPortalWayland : public AbstractWaylandPortal
 {
     Q_OBJECT
     Q_CLASSINFO("D-Bus Interface", "org.freedesktop.impl.portal.Screenshot")
+    Q_PROPERTY(uint version READ version CONSTANT)
 
 public:
-    ScreenshotPortalWayland(PortalWaylandContext *context);
+    explicit ScreenshotPortalWayland(PortalWaylandContext *context);
 
-    QString fullScreenShot();
-    QString captureInteractively();
+    uint version() const { return 2; }
 
 public Q_SLOTS:
     uint PickColor(const QDBusObjectPath &handle,
@@ -26,9 +27,11 @@ public Q_SLOTS:
                    const QString &parent_window,
                    const QVariantMap &options,
                    QVariantMap &results);
-    uint Screenshot(const QDBusObjectPath &handle,
+    void Screenshot(const QDBusObjectPath &handle,
                     const QString &app_id,
                     const QString &parent_window,
                     const QVariantMap &options,
-                    QVariantMap &results);
+                    const QDBusMessage &message,
+                    uint &replyResponse,
+                    QVariantMap &replyResults);
 };

--- a/src/xdg-desktop-portal-dde.cpp
+++ b/src/xdg-desktop-portal-dde.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
 #include "ddesktopportal.h"
+#include "access.h"
 #include "filechooser.h"
 #include "wayland/portalwaylandcontext.h"
 #include "wayland/toplevelmodel.h"
@@ -58,6 +59,7 @@ int main(int argc, char *argv[])
         if (onWayland()) {
             PortalWaylandContext *waylandContext = new PortalWaylandContext(&a);
             new FileChooserPortal(waylandContext);
+            new AccessPortal(waylandContext);
             if (sessionBus.registerObject(QStringLiteral("/org/freedesktop/portal/desktop"),
                                           waylandContext,
                                           QDBusConnection::ExportAdaptors)) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,5 @@
-find_package(Qt6 REQUIRED COMPONENTS Core DBus Widgets)
+find_package(Qt6 REQUIRED COMPONENTS Core DBus Gui Widgets)
+find_package(Dtk6 REQUIRED COMPONENTS Widget)
 
 add_executable(test-settings-dbus-metatype
     test_settings_dbus_metatype.cpp
@@ -20,3 +21,76 @@ add_test(NAME settings-dbus-metatype COMMAND test-settings-dbus-metatype)
 set_tests_properties(settings-dbus-metatype PROPERTIES
     ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
 )
+
+add_executable(test-screenshot-image
+    test_screenshot_image.cpp
+    ${CMAKE_SOURCE_DIR}/src/wayland/screenshotimage.cpp
+    ${CMAKE_SOURCE_DIR}/src/wayland/screenshotimage.h
+)
+
+target_include_directories(test-screenshot-image PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+)
+
+target_link_libraries(test-screenshot-image PRIVATE
+    Qt6::Core
+    Qt6::Gui
+)
+
+add_test(NAME screenshot-image COMMAND test-screenshot-image)
+
+add_executable(test-access-dialog
+    test_access_dialog.cpp
+    ${CMAKE_SOURCE_DIR}/src/accessdialog.cpp
+    ${CMAKE_SOURCE_DIR}/src/accessdialog.h
+    ${CMAKE_SOURCE_DIR}/src/accessdialogtypes.h
+)
+
+target_include_directories(test-access-dialog PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+)
+
+target_link_libraries(test-access-dialog PRIVATE
+    Dtk6::Widget
+    Qt6::Core
+    Qt6::DBus
+    Qt6::Widgets
+)
+
+add_test(NAME access-dialog COMMAND test-access-dialog)
+set_tests_properties(access-dialog PROPERTIES
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+)
+
+add_executable(test-access-dbus-types
+    test_access_dbus_types.cpp
+    ${CMAKE_SOURCE_DIR}/src/accessdialogtypes.cpp
+    ${CMAKE_SOURCE_DIR}/src/accessdialogtypes.h
+)
+
+target_include_directories(test-access-dbus-types PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+)
+
+target_link_libraries(test-access-dbus-types PRIVATE
+    Qt6::Core
+    Qt6::DBus
+)
+
+add_test(NAME access-dbus-types COMMAND test-access-dbus-types)
+
+add_executable(test-screenshot-interface
+    test_screenshot_interface.cpp
+)
+
+target_include_directories(test-screenshot-interface PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+)
+
+target_link_libraries(test-screenshot-interface PRIVATE
+    xdg-desktop-portal-dde-wayland
+    Qt6::Core
+    Qt6::DBus
+)
+
+add_test(NAME screenshot-interface COMMAND test-screenshot-interface)

--- a/tests/test_access_dbus_types.cpp
+++ b/tests/test_access_dbus_types.cpp
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "accessdialogtypes.h"
+
+#include <QCoreApplication>
+#include <QDBusMetaType>
+
+#include <cstring>
+#include <iostream>
+
+namespace
+{
+
+bool expectSignature(QMetaType type, const char *expected)
+{
+    const char *signature = QDBusMetaType::typeToSignature(type);
+    if (!signature || std::strcmp(signature, expected) != 0) {
+        std::cerr << "Expected D-Bus signature " << expected << ", got "
+                  << (signature ? signature : "<unregistered>") << '\n';
+        return false;
+    }
+    return true;
+}
+
+}
+
+int main(int argc, char *argv[])
+{
+    QCoreApplication application(argc, argv);
+    qDBusRegisterMetaType<AccessDialogTypes::Choice>();
+    qDBusRegisterMetaType<AccessDialogTypes::Choices>();
+    qDBusRegisterMetaType<AccessDialogTypes::Option>();
+    qDBusRegisterMetaType<AccessDialogTypes::OptionList>();
+
+    return expectSignature(QMetaType::fromType<AccessDialogTypes::Choices>(), "a(ss)")
+                    && expectSignature(QMetaType::fromType<AccessDialogTypes::OptionList>(),
+                                       "a(ssa(ss)s)")
+            ? 0
+            : 1;
+}

--- a/tests/test_access_dialog.cpp
+++ b/tests/test_access_dialog.cpp
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "accessdialog.h"
+
+#include <QAbstractButton>
+#include <QApplication>
+#include <QCheckBox>
+#include <QComboBox>
+
+#include <iostream>
+
+namespace
+{
+
+bool clickButton(AccessDialog &dialog, const QString &text)
+{
+    const auto buttons = dialog.findChildren<QAbstractButton *>();
+    for (auto button : buttons) {
+        if (button->text() == text) {
+            button->click();
+            return true;
+        }
+    }
+    return false;
+}
+
+bool expect(bool condition, const char *message)
+{
+    if (!condition) {
+        std::cerr << message << '\n';
+    }
+    return condition;
+}
+
+}
+
+int main(int argc, char *argv[])
+{
+    QApplication application(argc, argv);
+    const QVariantMap options{
+        {QStringLiteral("grant_label"), QStringLiteral("TEST_ALLOW")},
+        {QStringLiteral("deny_label"), QStringLiteral("TEST_DENY")},
+        {QStringLiteral("modal"), true},
+    };
+
+    AccessDialog allowDialog(QStringLiteral("Title"),
+                             QStringLiteral("Subtitle"),
+                             QStringLiteral("Body"),
+                             options,
+                             {});
+    if (!expect(allowDialog.windowModality() == Qt::WindowModal,
+                "Modal access dialog is not window-modal")
+        || !expect(clickButton(allowDialog, QStringLiteral("TEST_ALLOW")),
+                "Could not find the allow button")
+        || !expect(allowDialog.result() == QDialog::Accepted,
+                   "Allow button did not map to QDialog::Accepted")) {
+        return 1;
+    }
+
+    AccessDialog denyDialog(QStringLiteral("Title"),
+                            QStringLiteral("Subtitle"),
+                            QStringLiteral("Body"),
+                            options,
+                            {});
+    if (!expect(clickButton(denyDialog, QStringLiteral("TEST_DENY")),
+                "Could not find the deny button")
+        || !expect(denyDialog.result() == QDialog::Rejected,
+                   "Deny button did not map to QDialog::Rejected")) {
+        return 1;
+    }
+
+    const AccessDialogTypes::OptionList choices{
+        {QStringLiteral("remember"), QStringLiteral("Remember"), {}, QStringLiteral("false")},
+        {QStringLiteral("quality"),
+         QStringLiteral("Quality"),
+         {{QStringLiteral("low"), QStringLiteral("Low")},
+          {QStringLiteral("high"), QStringLiteral("High")}},
+         QStringLiteral("low")},
+    };
+    AccessDialog choicesDialog(QStringLiteral("Title"), {}, {}, options, choices);
+    auto checkBox = choicesDialog.findChild<QCheckBox *>();
+    auto comboBox = choicesDialog.findChild<QComboBox *>();
+    if (!expect(checkBox && comboBox, "Access choices controls were not created")) {
+        return 1;
+    }
+    checkBox->setChecked(true);
+    comboBox->setCurrentIndex(1);
+    const auto selected = choicesDialog.selectedChoices();
+    return expect(selected.size() == 2, "Access choices result has wrong size")
+            && expect(selected.at(0).value == QStringLiteral("true"),
+                      "Boolean access choice was not updated")
+            && expect(selected.at(1).value == QStringLiteral("high"),
+                      "Enumerated access choice was not updated")
+            ? 0
+            : 1;
+}

--- a/tests/test_screenshot_image.cpp
+++ b/tests/test_screenshot_image.cpp
@@ -1,0 +1,156 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "wayland/screenshotimage.h"
+
+#include <QColor>
+#include <QImage>
+
+#include <iostream>
+
+namespace
+{
+
+bool expect(bool condition, const char *message)
+{
+    if (!condition) {
+        std::cerr << message << '\n';
+    }
+    return condition;
+}
+
+QPoint transformedPoint(int transform, int x, int y, int width, int height)
+{
+    switch (transform) {
+    case 0:
+        return {x, y};
+    case 1:
+        return {height - 1 - y, x};
+    case 2:
+        return {width - 1 - x, height - 1 - y};
+    case 3:
+        return {y, width - 1 - x};
+    case 4:
+        return {width - 1 - x, y};
+    case 5:
+        return {y, x};
+    case 6:
+        return {x, height - 1 - y};
+    case 7:
+        return {height - 1 - y, width - 1 - x};
+    default:
+        return {};
+    }
+}
+
+bool testTransforms()
+{
+    QImage source(2, 3, QImage::Format_ARGB32);
+    for (int y = 0; y < source.height(); ++y) {
+        for (int x = 0; x < source.width(); ++x) {
+            source.setPixelColor(x, y, QColor(20 + x * 80, 30 + y * 60, 10 + x + y));
+        }
+    }
+
+    for (int transform = 0; transform < 8; ++transform) {
+        const QImage result = ScreenshotImage::normalizeOutput(source, transform, false);
+        const bool swapsAxes = transform % 2 == 1;
+        if (!expect(result.size() == (swapsAxes ? source.size().transposed() : source.size()),
+                    "Unexpected transformed image size")) {
+            return false;
+        }
+        for (int y = 0; y < source.height(); ++y) {
+            for (int x = 0; x < source.width(); ++x) {
+                const QPoint destination = transformedPoint(
+                        transform, x, y, source.width(), source.height());
+                if (!expect(result.pixelColor(destination) == source.pixelColor(x, y),
+                            "wl_output transform moved a pixel to the wrong location")) {
+                    return false;
+                }
+            }
+        }
+    }
+
+    const QImage inverted = ScreenshotImage::normalizeOutput(source, 0, true);
+    return expect(inverted.pixelColor(0, 0) == source.pixelColor(0, source.height() - 1),
+                  "Y-inverted screencopy image was not flipped");
+}
+
+bool testFractionalHorizontalLayout()
+{
+    QImage left(4, 4, QImage::Format_ARGB32);
+    left.fill(Qt::red);
+    QImage right(6, 6, QImage::Format_ARGB32);
+    right.fill(Qt::blue);
+
+    const QList<ScreenshotImage::Output> outputs{
+        {QRect(-100, -20, 4, 4), left, QStringLiteral("left")},
+        {QRect(-96, -20, 4, 4), right, QStringLiteral("right")},
+    };
+    const QImage result = ScreenshotImage::composeOutputs(outputs);
+    return expect(result.size() == QSize(10, 6), "Mixed-scale horizontal canvas has wrong size")
+            && expect(result.pixelColor(0, 0) == QColor(Qt::red), "Left output is missing")
+            && expect(result.pixelColor(4, 0) == QColor(Qt::blue), "Right output starts at wrong X")
+            && expect(result.pixelColor(0, 5).alpha() == 0, "Unused mixed-scale area is not transparent")
+            && expect(result.pixelColor(9, 5) == QColor(Qt::blue), "Right output was cropped");
+}
+
+bool testGapAndVerticalLayout()
+{
+    QImage top(2, 2, QImage::Format_ARGB32);
+    top.fill(Qt::green);
+    QImage bottom(4, 4, QImage::Format_ARGB32);
+    bottom.fill(Qt::yellow);
+
+    const QList<ScreenshotImage::Output> outputs{
+        {QRect(0, -4, 2, 2), top, QStringLiteral("top")},
+        {QRect(0, 0, 2, 2), bottom, QStringLiteral("bottom")},
+    };
+    const QImage result = ScreenshotImage::composeOutputs(outputs);
+    return expect(result.size() == QSize(4, 8), "Vertical layout with a gap has wrong size")
+            && expect(result.pixelColor(0, 0) == QColor(Qt::green), "Top output is missing")
+            && expect(result.pixelColor(0, 2).alpha() == 0, "Logical output gap was not preserved")
+            && expect(result.pixelColor(0, 4) == QColor(Qt::yellow), "Bottom output starts at wrong Y")
+            && expect(result.pixelColor(3, 7) == QColor(Qt::yellow), "Bottom output was cropped");
+}
+
+bool testThreeFractionalScales()
+{
+    QImage scale125(5, 5, QImage::Format_ARGB32);
+    scale125.fill(Qt::cyan);
+    QImage scale150(6, 6, QImage::Format_ARGB32);
+    scale150.fill(Qt::magenta);
+    QImage scale200(8, 8, QImage::Format_ARGB32);
+    scale200.fill(Qt::white);
+
+    const QList<ScreenshotImage::Output> outputs{
+        {QRect(0, 0, 4, 4), scale125, QStringLiteral("125-percent")},
+        {QRect(4, 0, 4, 4), scale150, QStringLiteral("150-percent")},
+        {QRect(8, 0, 4, 4), scale200, QStringLiteral("200-percent")},
+    };
+    const QImage result = ScreenshotImage::composeOutputs(outputs);
+    return expect(result.size() == QSize(19, 8), "Three-scale canvas has wrong size")
+            && expect(result.pixelColor(4, 0) == QColor(Qt::cyan), "125% output was cropped")
+            && expect(result.pixelColor(5, 0) == QColor(Qt::magenta), "150% output starts at wrong X")
+            && expect(result.pixelColor(10, 0) == QColor(Qt::magenta), "150% output was cropped")
+            && expect(result.pixelColor(11, 0) == QColor(Qt::white), "200% output starts at wrong X")
+            && expect(result.pixelColor(18, 7) == QColor(Qt::white), "200% output was cropped");
+}
+
+}
+
+int main()
+{
+    if (!testTransforms() || !testFractionalHorizontalLayout() || !testGapAndVerticalLayout()
+        || !testThreeFractionalScales()) {
+        return 1;
+    }
+
+    QString error;
+    if (!expect(ScreenshotImage::composeOutputs({}, &error).isNull() && !error.isEmpty(),
+                "Invalid composition did not report an error")) {
+        return 1;
+    }
+    return 0;
+}

--- a/tests/test_screenshot_interface.cpp
+++ b/tests/test_screenshot_interface.cpp
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "wayland/screenshotportal.h"
+#include "wayland/protocols/common.h"
+
+#include <QMetaMethod>
+#include <QMetaProperty>
+
+#include <iostream>
+
+namespace
+{
+
+bool expect(bool condition, const char *message)
+{
+    if (!condition) {
+        std::cerr << message << '\n';
+    }
+    return condition;
+}
+
+}
+
+int main()
+{
+    if (!expect(isSafeShmBufferLayout(1, 1, 4),
+                "A valid shared-memory layout was rejected")
+        || !expect(!isSafeShmBufferLayout(0, 1, 0),
+                   "A zero-width shared-memory layout was accepted")
+        || !expect(!isSafeShmBufferLayout(2, 1, 4),
+                   "A mismatched shared-memory stride was accepted")
+        || !expect(!isSafeShmBufferLayout(50000, 50000, 200000),
+                   "An overflowing Qt shared-memory allocation was accepted")) {
+        return 1;
+    }
+
+    const QMetaObject &metaObject = ScreenshotPortalWayland::staticMetaObject;
+    const int versionIndex = metaObject.indexOfProperty("version");
+    if (!expect(versionIndex >= 0, "Screenshot version property is missing")) {
+        return 1;
+    }
+
+    const QMetaProperty version = metaObject.property(versionIndex);
+    if (!expect(version.metaType() == QMetaType::fromType<uint>(),
+                "Screenshot version property has the wrong type")
+        || !expect(version.isReadable() && !version.isWritable(),
+                   "Screenshot version property must be read-only")) {
+        return 1;
+    }
+
+    bool foundDelayedScreenshot = false;
+    for (int i = metaObject.methodOffset(); i < metaObject.methodCount(); ++i) {
+        const QMetaMethod method = metaObject.method(i);
+        if (method.name() != QByteArrayLiteral("Screenshot")) {
+            continue;
+        }
+        const QList<QByteArray> parameters = method.parameterTypes();
+        foundDelayedScreenshot = method.returnType() == QMetaType::Void
+                && parameters.contains(QByteArrayLiteral("QDBusMessage"))
+                && parameters.contains(QByteArrayLiteral("uint&"))
+                && parameters.contains(QByteArrayLiteral("QVariantMap&"));
+    }
+
+    return expect(foundDelayedScreenshot,
+                  "Screenshot is not exposed with the delayed-reply signature")
+            ? 0
+            : 1;
+}


### PR DESCRIPTION
该PR相对于现在的弹窗, 改动了:
1. 修复了截图完没有正确发送close()请求
2. 修复了分数缩放情况下截图截不全的问题
3. 应用首次截图时, 增加类似于KDE Plasma的截图弹窗申请

该PR在 treeland 完成私有截图协议的实现后可以关闭, 该PR主要解决现在截图问题的燃眉之急（

The Wayland screenshot path used nested event loops and logical screen sizes. This made request cancellation unreliable and cropped mixed-scale multi-output captures. The backend also lacked a complete Access implementation, so the frontend could not show and persist the initial screenshot permission choice.

Run each screenshot as an asynchronous operation with a capture timeout and a request object that is unregistered on every completion path. Validate screencopy and Treeland buffers. Normalize output transforms, apply Y inversion, then compose buffers from logical output geometry. Save the result through QTemporaryFile to avoid filename collisions.

Implement the Access portal with the expected D-Bus choice signatures, allow/deny actions, optional choices, and modal parenting through xdg-foreign v2. Bind foreign parents only after Qt creates a real xdg_toplevel, leaving native file-dialog proxy surfaces untouched to avoid a fatal invalid_surface protocol error. After approval, destroy the dialog and wait for a Wayland display sync plus Treeland's close-animation grace period before replying, so the frontend does not request a frame while the permission dialog is still visible. Fail closed when the withdrawal barrier cannot be established.

Expose Screenshot version 2 and add tests for portal metadata, Access choices and D-Bus types, output transforms, and fractional-scale image composition.