### PR TITLE
fix(filechooser): return selected save filter

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -32,7 +32,7 @@ Architecture: any
 Depends:
   ${shlibs:Depends},
   ${misc:Depends}
-Description: Dtk poortal backend for xdg-desktop-portal
+Description: Dtk portal backend for xdg-desktop-portal
   xdg-desktop-portal-dde provide a DTK implementation for the
   desktop-agnostic xdg-desktop-portal service. This allows sandboxed
   applications to request services from outside the sandbox using

--- a/src/filechooser.cpp
+++ b/src/filechooser.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -105,6 +105,21 @@ const QDBusArgument &operator>>(const QDBusArgument &arg, FileChooserPortal::Opt
     option.initialChoiceId = initialChoiceId;
     arg.endStructure();
     return arg;
+}
+
+static QVariant currentFilterResult(const QFileDialog &fileDialog,
+                                    bool mimeFilters,
+                                    const QMap<QString, FileChooserPortal::FilterList> &allFilters)
+{
+    const QString selectedFilter = mimeFilters
+            ? fileDialog.selectedMimeTypeFilter()
+            : fileDialog.selectedNameFilter();
+    const auto filter = allFilters.constFind(selectedFilter);
+    if (filter != allFilters.cend()) {
+        return QVariant::fromValue<FileChooserPortal::FilterList>(filter.value());
+    }
+
+    return {};
 }
 
 Q_LOGGING_CATEGORY(fileChooserCategory, "xdg-dde-filechooser")
@@ -247,14 +262,9 @@ uint FileChooserPortal::OpenFile(const QDBusObjectPath &handle,
     results.insert(QStringLiteral("choices"), ""); // TODO
 
     // try to map current filter back to one of the predefined ones
-    QString selectedFilter;
-    if (bMimeFilters) {
-        selectedFilter = fileDialog.selectedMimeTypeFilter();
-    } else {
-        selectedFilter = fileDialog.selectedNameFilter();
-    }
-    if (allFilters.contains(selectedFilter)) {
-        results.insert(QStringLiteral("current_filter"), QVariant::fromValue<FilterList>(allFilters.value(selectedFilter)));
+    const QVariant currentFilter = currentFilterResult(fileDialog, bMimeFilters, allFilters);
+    if (currentFilter.isValid()) {
+        results.insert(QStringLiteral("current_filter"), currentFilter);
     }
 
     return 0;
@@ -336,7 +346,10 @@ uint FileChooserPortal::SaveFile(const QDBusObjectPath &handle,
     const auto &urls = fileDialog.selectedUrls();
     results.insert(QStringLiteral("uris"), QUrl::toStringList(urls, QUrl::FullyEncoded));
     results.insert(QStringLiteral("choices"), ""); // TODO
-    results.insert(QStringLiteral("current_filter"), ""); // TODO
+    const QVariant currentFilter = currentFilterResult(fileDialog, bMimeFilters, allFilters);
+    if (currentFilter.isValid()) {
+        results.insert(QStringLiteral("current_filter"), currentFilter);
+    }
 
     return 0;
 }
@@ -453,7 +466,7 @@ void FileChooserPortal::parseFilters(const QVariantMap &options,
                 const QString filterString = filterStrings.join(QLatin1Char(' '));
                 const QString nameFilter = QStringLiteral("%1(%2)").arg(userVisibleName, filterString);
                 nameFilters << nameFilter;
-                allFilters[filterList.userVisibleName] = filterList;
+                allFilters[nameFilter] = filterList;
             }
         }
     }
@@ -468,8 +481,8 @@ void FileChooserPortal::parseFilters(const QVariantMap &options,
 
         Filter filterStruct = filterList.filters.at(0);
         if (filterStruct.type == 0) {
-            QString userVisibleName = filterList.userVisibleName;
-            QString nameFilter = QStringLiteral("%1|(%2)").arg(filterStruct.filterString, userVisibleName);
+            const QString nameFilter = QStringLiteral("%1(%2)").arg(filterList.userVisibleName,
+                                                                    filterStruct.filterString);
             nameFilters.removeAll(nameFilter);
             nameFilters.push_front(nameFilter);
         } else {


### PR DESCRIPTION
1. Return the selected filter with the correct D-Bus type in SaveFile responses.
2. Reuse filter result conversion for open and save dialogs.
3. Align glob filter keys and initial filter formatting with QFileDialog.
4. Correct the portal spelling in the Debian package description.

Log: Return the selected file filter in save responses
Influence: Save responses include the selected filter.

fix(filechooser): 返回保存时选中的过滤器

1. 在 SaveFile 响应中以正确的 D-Bus 类型返回选中过滤器。
2. 复用打开和保存对话框的过滤器结果转换逻辑。
3. 统一通配符过滤器键值和 QFileDialog 初始过滤器格式。
4. 修正 Debian 软件包描述中的 portal 拼写。

Log: 在保存响应中返回选中的文件过滤器
PMS: BUG-368945
Influence: 保存响应可正确携带选中过滤器。

## Summary by Sourcery

Return the selected file filter from file chooser dialogs and align filter handling with QFileDialog formats.

New Features:
- Include the selected file filter in SaveFile D-Bus responses using the correct variant type.

Bug Fixes:
- Ensure SaveFile responses carry the correct selected filter instead of an empty placeholder.
- Correct mismatch between glob filter keys and QFileDialog initial filter formatting so current filters can be mapped back reliably.
- Fix spelling of the portal name in the Debian package description.

Enhancements:
- Reuse a shared helper to compute the current filter result for both open and save file dialogs.
- Update copyright years in the file chooser implementation header comment.